### PR TITLE
Add default scale constraints for Korean fiction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 When the user asks for Korean fiction work in this workspace, do not answer from generic writing instincts alone.
 
+When planning or drafting, apply these default scale constraints unless the user explicitly specifies otherwise:
+- **Project Scale:** Plan longform projects and web novels for a total of 150~200 chapters (화).
+- **Chapter Length:** Draft each chapter to reach 5000~6000 characters (공백 포함 5000~6000자) for a standard manuscript.
+
 Treat these requests as covered by the local `novel-writing` skill, even if the user does not explicitly invoke a skill name:
 
 - planning or outlining a Korean novel, web novel, or serialized fiction

--- a/skills/longform-story-design/references/longform-workflow.md
+++ b/skills/longform-story-design/references/longform-workflow.md
@@ -45,7 +45,7 @@ The exact ending can stay open, but the category of promise should be visible ea
 Lock early:
 
 - target format: long novel, saga, serialized web novel, trilogy, etc.
-- planned scale: approximate chapter count, volume count, or arc count
+- planned scale: approximate chapter count (default 150-200 chapters for web novels unless specified otherwise), volume count, or arc count
 - genre and audience
 - growth model: static cast, expanding ensemble, factional expansion, power progression, romance escalation, mystery layering
 - drafting mode: preplanned, rolling outline, or hybrid

--- a/skills/longform-story-design/references/project-frame-template.md
+++ b/skills/longform-story-design/references/project-frame-template.md
@@ -20,7 +20,7 @@ Primary risk:
 
 - `Format`: long novel, web novel, trilogy, saga, season-based serial, or equivalent
 - `Structure mode`: linear arc, braided ensemble, omnibus, rotating-focus serial, or equivalent when structurally relevant
-- `Scale`: chapter count, arc count, volume count, or the cleanest available scale marker
+- `Scale`: chapter count (default to 150-200 chapters if unspecified), arc count, volume count, or the cleanest available scale marker
 - `Genre / audience`: combine genre and likely readership tendency in one line
 - `Genre package`: one dominant package, with a secondary package only when hybrid is structurally relevant
 - `Package selection reason`: mandatory one-sentence justification tied to chapter-return engine, volume-end promise, or dominant failure mode

--- a/skills/longform-story-design/references/project-intake.md
+++ b/skills/longform-story-design/references/project-intake.md
@@ -8,7 +8,7 @@ Extract or infer these fields first:
 
 - format: long novel, web novel, trilogy, saga, season-based serial
 - structure mode, if relevant: linear arc, braided ensemble, omnibus, rotating-focus serial
-- scale: expected chapter count, arc count, or volume count
+- scale: expected chapter count (default 150-200 chapters), arc count, or volume count
 - genre and audience tendency
 - user-stated genre label, if any
 - likely chapter-return engine

--- a/skills/novel-writing/SKILL.md
+++ b/skills/novel-writing/SKILL.md
@@ -26,7 +26,7 @@ Identify the immediate output before writing:
 If the user asks for prose, treat the task as manuscript production unless they explicitly want notes only.
 Default to returning `원고`. If the user explicitly asks for `초고`, `개고`, or another intermediate stage, return that requested stage instead while still saving the full stage set unless the user says not to.
 
-Lock the operating constraints early: genre, target audience, point of view, tense, tone, target length, completion state, and any banned content or required themes. If the user omits these, make the smallest useful assumption set explicit before drafting.
+Lock the operating constraints early: genre, target audience, point of view, tense, tone, target length (default to 5000~6000 characters per chapter unless specified otherwise), completion state, and any banned content or required themes. If the user omits these, make the smallest useful assumption set explicit before drafting.
 When POV matters, decide not only `1인칭` or `3인칭`, but also narration distance, knowledge limit, and whether the voice is character-colored or relatively neutral.
 
 Assume the output language is Korean unless the user explicitly requests bilingual or translated material.

--- a/skills/novel-writing/references/workflow.md
+++ b/skills/novel-writing/references/workflow.md
@@ -11,7 +11,7 @@ Capture the minimum brief:
 - POV and tense
 - if POV is important, decide `1인칭`, `3인칭 제한`, or a more distant third-person stance before drafting
 - Korean register target: literary, commercial, web novel, YA, etc.
-- desired length
+- desired length (default 5000~6000 characters per chapter unless otherwise specified)
 - must-include and must-avoid elements
 - current manuscript state
 


### PR DESCRIPTION
Added instructions to default to 150-200 chapters for longform projects and 5000-6000 characters per chapter unless the user specifies otherwise.

---
*PR created automatically by Jules for task [18161839115114154114](https://jules.google.com/task/18161839115114154114) started by @Hanjo92*