### PR TITLE
[codex] Harden series completion loop guardrails

### DIFF
--- a/skills/series-completion-loop/SKILL.md
+++ b/skills/series-completion-loop/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: series-completion-loop
-description: Use when a Korean long-form project must keep progressing toward completion across many sessions or automation runs by moving the next valid 3~5화 batch through planning, drafting, QA, recovery, and state updates.
+description: Use when a Korean long-form project already has an explicit projects/<series-slug>/ runtime and must progress safely across sessions, automation runs, approval gates, QA recovery, or bounded 3~5화 batches.
 ---
 
 # Series Completion Loop
 
 ## Overview
 Use this skill as a state-based orchestrator for Korean long-form fiction completion. It reads runtime state, chooses the next valid transition, and delegates the actual work to specialist skills instead of replacing them.
+
+## Entry Gate
+Operate only on one explicit, pre-existing `projects/<series-slug>/` runtime selected by the user, automation prompt, or current runtime files.
+
+- If no runtime is selected, stop and report the missing project runtime.
+- If multiple runtimes are plausible, stop and report the ambiguity.
+- Never infer project identity, batch scope, or story intent from chat context.
+- Never draft, bootstrap, or create `projects/<series-slug>/` from implicit conversation context.
+- Bootstrap means enriching an existing runtime, not inventing one.
 
 ## Hard Ownership
 Use this skill when the task is to keep a series moving through a bounded loop across sessions, runs, or automation. Hand work off immediately when the current step belongs to a specialist:
@@ -17,6 +26,20 @@ Use this skill when the task is to keep a series moving through a bounded loop a
 - `character-voice-bible` for dialogue and cast voice control
 
 Do not use this skill to write the whole series in one pass, redesign the story world, or perform specialist QA inline when the specialist skill should own the step.
+
+## Specialist Handoff Contract
+When delegating, pass only the current batch context:
+
+- `project.md`
+- `state/runtime.yaml`
+- `state/active-slice.yaml`
+- `state/handoff.md`
+- relevant ledgers for the active transition
+- the minimum current artifact required by the state, such as the latest manuscript batch for `qa_review`
+
+The specialist owns the domain work product for the current state. The orchestrator may update only runtime, handoff, and artifact pointers afterward; it must not rewrite specialist output except to persist the returned artifact as-is.
+
+Scope every delegated task to `current_batch_start` through `current_batch_end`. Do not include future-slice material. Before and after each handoff, verify that `state/active-slice.yaml` still matches the current manuscript batch. If the batch boundary moved or next-slice work was pulled forward, stop at `blocked` or re-enter from the last valid boundary.
 
 ## Canonical Loop Order
 Follow this order unless runtime state says a different valid transition is needed:
@@ -91,6 +114,19 @@ Keep every run tightly bounded:
 - Never attempt the entire series in one run
 - Never replace specialist skills with a full manual rewrite
 - Stop once the next valid transition is complete and the handoff files are updated
+
+## Stop Evidence
+Do not stop a production run until `state/runtime.yaml` and `state/handoff.md` show:
+
+- the completed transition
+- `state`
+- `next_action`
+- `current_batch_start` and `current_batch_end`
+- artifact paths created, reviewed, or accepted in the run
+- `last_run_at`
+- `last_completed_stage` or `blocked_reason`
+
+When marking `completed` or `blocked`, name the exact predicate satisfied and the artifact path that proves it. If no proof exists, stay in the prior valid state or mark `blocked` rather than pretending the transition completed.
 
 ## Failure And Re-entry
 Before each run, snapshot the current runtime state so re-entry is possible. At minimum, archive:

--- a/skills/series-completion-loop/agents/openai.yaml
+++ b/skills/series-completion-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Series Completion Loop"
   short_description: "State-based orchestration for long-running Korean fiction completion."
-  default_prompt: "Use $series-completion-loop to move a Korean long-form project through the next valid 3~5화 batch by reading runtime state, dispatching the correct specialist skill, updating handoff files, and stopping after a bounded transition."
+  default_prompt: "Use $series-completion-loop only for an explicit projects/<series-slug>/ runtime. Move the project through the next valid 3~5화 bounded transition, delegate specialist work, update runtime and handoff evidence, and stop."

--- a/skills/series-completion-loop/references/automation-prompts.md
+++ b/skills/series-completion-loop/references/automation-prompts.md
@@ -2,8 +2,12 @@
 
 ## Production Run
 
-- read `runtime.yaml`
+- resolve exactly one selected `projects/<series-slug>/` runtime
+- if no runtime is selected, report missing runtime only
+- if multiple runtimes are plausible, report ambiguity only
+- read `state/runtime.yaml`
 - perform the next valid bounded action only
+- never draft, bootstrap, or reconstruct state from chat context
 - update `state/runtime.yaml`
 - update `state/handoff.md`
 - stop
@@ -12,7 +16,10 @@ Required closing fields:
 
 - `state`
 - `next_action`
+- `current_batch_start`
+- `current_batch_end`
 - `last_run_at`
+- artifact path or reviewed artifact path
 - `last_completed_stage` or `blocked_reason`
 
 ## Safety Run

--- a/skills/series-completion-loop/references/failure-reentry.md
+++ b/skills/series-completion-loop/references/failure-reentry.md
@@ -8,6 +8,7 @@ Snapshot before each run:
 
 Block conditions:
 
+- missing or ambiguous selected project runtime
 - missing state
 - contradictory state
 - same slice QA fails twice without a changed repair direction
@@ -18,6 +19,8 @@ Block conditions:
 
 Operational checks:
 
+- missing selected runtime means no explicit, pre-existing `projects/<series-slug>/` path was supplied by the user, automation prompt, or current runtime files
+- ambiguous selected runtime means more than one `projects/<series-slug>/` path could plausibly match the request; do not choose from chat context
 - missing state means any required file is absent, or a required key is absent from the file that owns it
 - required `project.md` fields are Title, Slug, Target scale, Completion mode, Default batch size, and Ending promise
 - required `state/runtime.yaml` keys are `mode`, `state`, `next_action`, `approval_pending`, `last_approval_at`, `last_approval_batch_start`, `last_approval_batch_end`, `last_approval_note`, `current_batch_start`, `current_batch_end`, `latest_manuscript_batch`, `last_run_at`, `failure_count`, `blocked_reason`, and `last_completed_stage`
@@ -28,6 +31,7 @@ Operational checks:
 - repeated recovery means two consecutive runs have `state: recovery_planning` without changing `state/active-slice.yaml` or `recovery/latest-recovery.md`
 - active-slice divergence means `state/active-slice.yaml` chapter range does not match the newest saved manuscript batch named in `state/runtime.yaml`
 - undefined completion means `project.md` has no ending promise, target scale, or completion condition while `next_action` is `slice_planning`
+- unproven stop means `state/runtime.yaml` or `state/handoff.md` lacks the artifact path or predicate that proves `completed`, `blocked`, or the completed transition; stay in the prior valid state or mark `blocked`
 
 Recovery rules:
 

--- a/skills/series-completion-loop/references/runtime-layout.md
+++ b/skills/series-completion-loop/references/runtime-layout.md
@@ -13,6 +13,12 @@ Runtime files live under `projects/<series-slug>/` and are the only project-scop
 - `projects/<series-slug>/recovery/latest-recovery.md`
 - `projects/<series-slug>/archive/runs/`
 
+Selection rule:
+
+- operate only on one explicit, pre-existing `projects/<series-slug>/` runtime
+- do not infer the slug, project identity, or batch scope from chat context
+- do not create project runtime folders, state files, or ledgers unless the user explicitly requested project setup outside this loop
+
 Separation rule:
 
 - manuscript stays in `drafts/`
@@ -26,6 +32,13 @@ Touching rule:
 ## Transition Ownership Matrix
 
 Use this as the default read/write boundary. Specialist skills may write their own outputs, but the orchestrator should only touch these runtime files directly.
+
+Delegation rule:
+
+- pass only current-batch runtime context to specialist skills
+- specialists own prose, QA, dialogue, design, and recovery artifacts
+- after a specialist returns, the orchestrator updates only runtime, handoff, and artifact pointers
+- if specialist work would require the next batch, stop and hand off instead of extending scope
 
 | State | Read | Write |
 | --- | --- | --- |

--- a/skills/series-completion-loop/references/state-machine.md
+++ b/skills/series-completion-loop/references/state-machine.md
@@ -41,6 +41,13 @@ Run boundary:
 - the only allowed adjacent pairs are `slice_planning -> drafting` and `qa_review -> ready_next_slice`
 - do not expand a run beyond the current batch boundary
 - if the next valid step would cross into a new batch, stop and hand off instead of continuing
+- before and after specialist handoff, verify that `state/active-slice.yaml` matches `current_batch_start` and `current_batch_end`
+
+Stop evidence:
+
+- `state/runtime.yaml` records the completed transition, batch range, next state, next action, timestamp, and artifact pointer
+- `state/handoff.md` records what finished, what artifact proves it, and where the next run resumes
+- `completed` and `blocked` require the exact predicate and proof artifact path before the run may stop
 
 Mode-specific transition authority:
 


### PR DESCRIPTION
## Summary
- Harden `series-completion-loop` so it only operates on an explicit pre-existing `projects/<series-slug>/` runtime.
- Add specialist handoff guardrails that keep delegated work scoped to the current batch and preserve specialist ownership.
- Require end-of-run evidence in runtime and handoff files, including artifact paths and completed/blocked predicates.

## Validation
- Pressure scenario review: missing runtime / implicit chat context approved
- Pressure scenario review: specialist handoff contract approved
- Pressure scenario review: stop evidence approved
- `rg -n 'Entry Gate|Specialist Handoff Contract|Stop Evidence|pre-existing `projects/<series-slug>/`|never draft, bootstrap, or reconstruct|Delegation rule|unproven stop|artifact path' skills/series-completion-loop`
- `find skills/series-completion-loop -maxdepth 3 -type f | sort`
- `git diff --check`
