### PR TITLE
[codex] Harden series QA handoff intake

### DIFF
--- a/skills/series-qa/SKILL.md
+++ b/skills/series-qa/SKILL.md
@@ -10,12 +10,24 @@ description: Audit long-form Korean fiction manuscripts, chapter batches, story 
 Use this skill to inspect accumulated Korean fiction materials and identify the smallest set of failures causing reader-visible weakness. Focus on diagnosis, evidence, and repair priority rather than on fresh drafting.
 
 This skill is diagnosis-only. Do not rebuild chapters, scenes, arcs, cast sheets, or story systems here.
-Do not take ownership of downstream repair execution, rewrite architecture, or prose reconstruction.
+Do not take ownership of downstream repair execution, rewrite architecture, prose reconstruction, runtime updates, ledger edits, or planning-file edits.
 If the request needs a design pass, drafting pass, or character rewrite pass, hand it off instead of expanding scope.
 
 If the user needs the output to become a reusable reconstruction package rather than a ranked diagnosis, hand the work to `longform-story-design`.
 If the problem is primarily chapter prose, narration, scene flow, or longform drafting shape, hand the work to `novel-writing`.
 If the problem is primarily speaker voice, dialogue register, or cast interaction behavior, hand the work to `character-voice-bible`.
+
+## Orchestrator Handoff Intake
+
+When invoked by `series-completion-loop` in `qa_review`, treat `current_batch_start` through `current_batch_end` as the hard audit window.
+
+- Name the active batch before any finding.
+- Audit only the active batch unless evidence inside that batch points backward to a prior break.
+- Expand only backward to locate the first break point, and only as far as the evidence requires.
+- Never inspect future batches or the whole project unless the handoff explicitly re-authorizes that scope.
+- Keep prior-batch material as supporting context, not as a new audit range.
+
+Do not update `state/runtime.yaml`, `state/handoff.md`, ledgers, planning artifacts, or manuscripts. Return a QA artifact the orchestrator can use to update state.
 
 ## Choose The Audit Mode
 
@@ -25,7 +37,7 @@ Match the depth of the audit to the user's real need:
 - arc checkpoint: audit one arc, season, or volume segment for drift before drafting continues
 - full diagnosis: map structural, continuity, pacing, and payoff failures across a long range
 
-Default to the smallest mode that can answer the complaint cleanly.
+Default to the smallest mode that can answer the complaint cleanly. In an orchestrated `qa_review`, do not choose full diagnosis unless the handoff explicitly authorizes a range beyond the active batch.
 
 ## Canonical Diagnostic Order
 
@@ -78,7 +90,7 @@ Do not read a 200-chapter run by default. Start from:
 - the chapter immediately before the symptom if drift is suspected
 - the planning artifact that should have prevented the failure
 
-Expand the range only if the local evidence points backward.
+Expand the range only if the local evidence points backward. Do not expand forward into future batches while answering an active-batch QA handoff.
 
 ## Sample Intelligently
 
@@ -199,14 +211,18 @@ For installment-specific checks, read [references/serialization-checks.md](refer
 
 Default to this structure unless the user requests a different format:
 
-1. what is working
-2. highest-risk failures
-3. severity and confidence
-4. chapter or scene evidence
-5. likely reader-visible symptom
-6. smallest viable repair direction
-7. downstream handoff target
-8. optional re-audit note
+1. active batch or audit range
+2. outcome: `ready_next_slice`, `needs_recovery`, or `blocked`
+3. what is working
+4. highest-risk failures
+5. severity and confidence
+6. root cause or downstream symptom classification
+7. chapter or scene evidence
+8. artifact evidence
+9. likely reader-visible symptom
+10. smallest viable repair direction
+11. downstream handoff target
+12. re-audit gate
 
 For reusable report layouts, read [references/report-templates.md](references/report-templates.md).
 Keep the output QA-first: it should support decision-making, not imply that this skill is responsible for reconstruction.
@@ -238,6 +254,7 @@ Examples:
 
 The report should make clear what to repair first to collapse the largest number of downstream failures.
 Describe the repair only as a direction, dependency, or constraint. Do not turn it into a rebuild plan or step-by-step reconstruction inside this skill.
+Classify each confirmed finding explicitly as `root cause` or `downstream symptom`. Do not leave the top issue as symptom-only.
 
 ## Severity Rule
 
@@ -292,6 +309,8 @@ Use the re-audit gate as the end of the diagnostic loop: once the issue is repai
 - Prefer a narrower but defensible finding over a broad but weak conclusion.
 - Name the downstream owner when the next step is structural recovery, prose rewrite, or dialogue-layer repair.
 - Do not produce reconstruction packages, re-entry drafting packets, or rewrite plans in this skill.
+- When a repair direction changes after re-audit, mark it as `unchanged`, `narrowed`, or `changed` and explain why.
+- When the output will feed `series-completion-loop`, include artifact paths or state pointers that prove the diagnosis, recheck, or blocked result.
 
 ## Relationship To Other Skills
 

--- a/skills/series-qa/agents/openai.yaml
+++ b/skills/series-qa/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Series QA"
   short_description: "Diagnosis and triage for Korean long-form fiction problems."
-  default_prompt: "Use $series-qa to diagnose continuity breaks, pacing problems, payoff failures, narration instability, or dialogue drift in a Korean long-form manuscript or web novel arc."
+  default_prompt: "Use $series-qa to diagnose the active manuscript range or series-completion-loop handoff, return root-cause findings, handoff target, re-audit gate, and artifact evidence, and avoid rewriting or updating runtime state."
 
 policy:
   allow_implicit_invocation: true

--- a/skills/series-qa/references/planning-sync-checks.md
+++ b/skills/series-qa/references/planning-sync-checks.md
@@ -97,16 +97,17 @@ When reporting planning sync failure, name:
 
 Do not report "out of sync" without naming both sides of the mismatch.
 
-## Repair Rule
+## Repair Direction Rule
 
-Repair planning sync failures by restoring one active source of truth. Prefer:
+Report planning sync repair as a handoff direction, not as QA-owned file editing. Prefer:
 
 1. choose the authoritative version
-2. update or retire stale planning artifacts
-3. align trackers with current manuscript state
-4. define which document must be updated after each drafting batch
+2. name the stale or conflicting planning artifact
+3. name which tracker should be aligned with current manuscript state
+4. define which downstream owner should update the document after each drafting batch
 
 Do not preserve multiple competing versions of the same fact just to avoid choosing.
+Do not update, retire, rewrite, or align planning files inside QA.
 
 ## Recheck Questions
 

--- a/skills/series-qa/references/report-templates.md
+++ b/skills/series-qa/references/report-templates.md
@@ -12,12 +12,15 @@ For genre-specific completed examples, read [sample-romance-qa-report.md](sample
 Write in QA language, not workshop language.
 
 - state scope before judgment
+- name the active batch first when invoked by `series-completion-loop`
 - separate confirmed findings from hypotheses
 - cite evidence by chapter, scene, or document location
+- cite artifact evidence by file path or state pointer when the output feeds an orchestrator
 - rank by severity and repair priority
 - define what a passing recheck would require
 - keep repair language directional, not reconstructive
 - name the downstream owner when the next step leaves QA scope
+- include an outcome: `ready_next_slice`, `needs_recovery`, or `blocked`
 
 Avoid:
 
@@ -31,14 +34,23 @@ Avoid:
 
 ```text
 Audit scope:
+- Active batch:
 - Manuscript range:
 - Planning documents checked:
 - Audit mode:
 - Sampling limit:
+- Earlier material sampled:
 
 Complaint under test:
 - Reported symptom:
 - Working hypothesis:
+
+Orchestrator outcome:
+- Outcome: ready_next_slice | needs_recovery | blocked
+- Artifact evidence:
+- Repair direction status: unchanged | narrowed | changed | first pass
+- Handoff target:
+- Re-audit gate:
 
 Scope note:
 - What was checked:
@@ -49,26 +61,30 @@ Confirmed findings:
 1. Finding title:
    Severity:
    Confidence:
-   Root cause or symptom:
+   Classification: root cause | downstream symptom:
    First break point:
    Evidence:
+   Artifact evidence:
    Expected function:
    Observed failure:
    Reader-visible damage:
    Repair direction:
+   Repair direction status:
    Handoff target:
    Recheck condition:
 
 2. Finding title:
    Severity:
    Confidence:
-   Root cause or symptom:
+   Classification: root cause | downstream symptom:
    First break point:
    Evidence:
+   Artifact evidence:
    Expected function:
    Observed failure:
    Reader-visible damage:
    Repair direction:
+   Repair direction status:
    Handoff target:
    Recheck condition:
 
@@ -88,19 +104,26 @@ Revision priority:
 
 ```text
 Handoff range:
+- Active batch:
 - Chapter / arc / volume range:
 - Core diagnosed failure:
+- Outcome: ready_next_slice | needs_recovery | blocked
+- Artifact evidence:
 
 Directional repair:
 1. Issue:
+   Classification: root cause | downstream symptom:
    Why it comes first:
    High-level fix type:
+   Repair direction status:
    Downstream owner:
    Recheck after downstream revision:
 
 2. Issue:
+   Classification: root cause | downstream symptom:
    Why it comes first:
    High-level fix type:
+   Repair direction status:
    Downstream owner:
    Recheck after downstream revision:
 
@@ -115,6 +138,7 @@ Open risks after this pass:
 
 ```text
 Arc checked:
+Active batch:
 Audit basis:
 
 Status:
@@ -128,6 +152,12 @@ Primary failure:
 - ...
 
 First break point:
+- ...
+
+Outcome:
+- ready_next_slice | needs_recovery | blocked
+
+Artifact evidence:
 - ...
 
 Repair direction:
@@ -144,6 +174,7 @@ Recheck gate:
 
 ```text
 Episode range checked:
+Active batch:
 Sampling basis:
 
 Retention-facing finding:
@@ -156,6 +187,12 @@ Story-health finding:
 - Core failure:
 - Evidence:
 - Reader trust risk:
+
+Outcome:
+- ready_next_slice | needs_recovery | blocked
+
+Artifact evidence:
+- ...
 
 Repair direction:
 - ...
@@ -171,20 +208,27 @@ Pass condition on recheck:
 
 ```text
 Range checked:
+Active batch:
 Complaint:
 
 Top issue:
 - Severity:
+- Classification: root cause | downstream symptom:
 - Evidence:
+- Artifact evidence:
 - First break point:
 - Repair direction:
+- Repair direction status:
 - Handoff target:
 
 Second issue:
 - Severity:
+- Classification: root cause | downstream symptom:
 - Evidence:
+- Artifact evidence:
 - First break point:
 - Repair direction:
+- Repair direction status:
 - Handoff target:
 
 Not checked:

--- a/skills/series-qa/references/sample-mystery-qa-report.md
+++ b/skills/series-qa/references/sample-mystery-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. Mid-arc clues add information but do not change investigative behavior
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 11
    Evidence: Chapters 11, 13, and 15 each deliver new case details, but the protagonist's theory, suspect priority, and risk profile remain effectively unchanged after each discovery.
    Expected function: Each significant clue should alter suspicion, decision-making, or pressure.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. The Chapter 18 reveal answers the question without reframing prior scenes
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 18
    Evidence: The solution identifies the culprit and explains motive, but earlier clue scenes read the same after the reveal and no previously ambiguous behavior gains new meaning.
    Expected function: A mystery reveal should answer and recontextualize.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. Investigator agency drops during the mid-case run
    Severity: Medium
    Confidence: Medium
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Chapter 12
    Evidence: The investigation advances through witness convenience and villain disclosure more often than through deliberate probing by the protagonist.
    Expected function: The investigator should generate pressure by choosing tests, risks, and lines of inquiry.

--- a/skills/series-qa/references/sample-political-intrigue-qa-report.md
+++ b/skills/series-qa/references/sample-political-intrigue-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. Faction goals are no longer distinct enough to produce sharp conflict
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 50
    Evidence: By Chapters 50-54, three court factions are all effectively pushing for generic stability language, while their risk tolerance, preferred methods, and succession preferences stop producing clearly different strategic moves.
    Expected function: Each major faction should create pressure through distinct incentives, acceptable costs, and preferred tools.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. The Chapter 56 betrayal lands as surprise rather than as earned strategic outcome
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 56
    Evidence: The betraying minister has presence in earlier chapters, but the sampled range does not build enough visible pressure, leverage, or narrowing options to make the turn feel inevitable in retrospect.
    Expected function: A political betrayal should read as both surprising in the moment and legible after review.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. Institutional rules stop constraining elite action
    Severity: Medium
    Confidence: Medium
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Chapter 53
    Evidence: Council procedure, succession protocol, and guard authority matter heavily in earlier chapters, but Chapters 53-58 allow high-ranking characters to bypass formal limits whenever speed is needed.
    Expected function: Institutions in political fiction should shape what can be attempted and at what cost.

--- a/skills/series-qa/references/sample-progression-fantasy-qa-report.md
+++ b/skills/series-qa/references/sample-progression-fantasy-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. Rank-up gains are not changing challenge type
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Episode 45
    Evidence: After the mid-arc breakthrough, the protagonist keeps facing stronger versions of the same combat problem rather than needing new tactics, tradeoffs, or strategic thinking.
    Expected function: Progression should unlock qualitatively different obstacles, not only higher numbers.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. Training loop repetition is dulling the arc
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Episode 43
    Evidence: Episodes 43, 46, and 49 repeat a similar train-fail-adjust-improve sequence with only superficial changes in terminology and environment.
    Expected function: Each training stage should alter stakes, method, or consequence.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. Breakthrough cost is fading too quickly
    Severity: Medium
    Confidence: Medium
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Episode 47
    Evidence: The breakthrough initially imposes bodily strain and resource drain, but those burdens stop constraining action within two episodes.
    Expected function: A major gain should carry visible price long enough to shape subsequent choices.

--- a/skills/series-qa/references/sample-qa-report.md
+++ b/skills/series-qa/references/sample-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. Repeated hesitation beat is flattening the middle of the arc
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 34
    Evidence: Chapters 34, 36, and 38 all end with the protagonist delaying the same commitment without a new cost, reversal, or information shift.
    Expected function: Each chapter should escalate the commitment problem or alter the cost of refusal.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. Early setup around the sealed archive pays off too late and too weakly
    Severity: High
    Confidence: Medium
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 33
    Evidence: The archive is framed as a major risk in Chapters 31-33, but the return in Chapter 41 provides information only and does not alter trust, strategy, or faction balance.
    Expected function: A promised high-risk reveal should materially shift character decisions or power relations.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. Continuity tracking around injury state is drifting
    Severity: Medium
    Confidence: High
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Chapter 37
    Evidence: The shoulder injury limits combat movement in Chapter 37, is ignored during the pursuit sequence in Chapter 39, and returns as active pain in Chapter 40 without explanation.
    Expected function: Injury state should either persist consistently or be explicitly reset.
@@ -68,7 +68,7 @@ What is still working:
 Revision priority:
 1. Remove the repeated hesitation loop in Chapters 34-38.
 2. Strengthen the archive payoff in Chapter 41 so it changes action, trust, or stakes.
-3. Repair injury-state continuity in Chapters 37-40 and update the ledger.
+3. Repair injury-state continuity in Chapters 37-40 and hand off ledger alignment to the continuity owner.
 ```
 
 ## Why This Example Works

--- a/skills/series-qa/references/sample-romance-qa-report.md
+++ b/skills/series-qa/references/sample-romance-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. The pair is circling the same near-confession beat without new emotional price
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 24
    Evidence: Chapters 24, 27, and 30 each stage an almost-confession followed by withdrawal, but the withdrawals do not cost trust, status, or opportunity in a way that changes the next interaction.
    Expected function: Repeated delay beats should either deepen vulnerability or alter the relationship state.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. Emotional risk is unevenly distributed
    Severity: Medium
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Chapter 25
    Evidence: One lead repeatedly admits fear, asks for clarification, and changes behavior, while the other retains mystery without paying comparable emotional cost.
    Expected function: Both sides of the central pair should carry visible romantic risk.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. The breakthrough at Chapter 21 is not being carried forward
    Severity: Medium
    Confidence: Medium
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Chapter 22
    Evidence: The late-Chapter 21 intimacy shift is treated as meaningful in the moment, but Chapters 22-26 revert to pre-breakthrough caution patterns with little behavioral residue.
    Expected function: A breakthrough should change later address, access, jealousy logic, or emotional threshold.

--- a/skills/series-qa/references/sample-serialization-qa-report.md
+++ b/skills/series-qa/references/sample-serialization-qa-report.md
@@ -24,7 +24,7 @@ Confirmed findings:
 1. End hooks are varying in wording but not in promise shape
    Severity: High
    Confidence: High
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Episode 88
    Evidence: Episodes 88, 90, 92, and 94 all end on a reveal-tease pattern, but the following episodes resolve into partial explanation or repositioning instead of a changed decision, loss, or confrontation.
    Expected function: End hooks should create a distinct next-episode obligation that produces new story value, not just more anticipation.
@@ -36,7 +36,7 @@ Confirmed findings:
 2. Recap burden is crowding out early-scene movement
    Severity: Medium
    Confidence: High
-   Root cause or symptom: Downstream symptom
+   Classification: Downstream symptom
    First break point: Episode 87
    Evidence: Episodes 87-91 spend the first third of the runtime restating prior danger, current faction positions, or emotional hesitation before any fresh pressure arrives.
    Expected function: Serial recaps should reorient quickly and hand off to new pressure.
@@ -48,7 +48,7 @@ Confirmed findings:
 3. Promised reward cadence is slipping behind the delay pattern
    Severity: High
    Confidence: Medium
-   Root cause or symptom: Root cause
+   Classification: Root cause
    First break point: Episode 86
    Evidence: Major teased threads across Episodes 86-95 mostly defer payoff, while the only resolved thread in Episode 93 returns as information without emotional or tactical gain.
    Expected function: A delayed serial arc should still return meaningful reward at regular intervals through wins, reversals, reveals with force, or relationship changes.


### PR DESCRIPTION
## Summary
- Harden `series-qa` so `series-completion-loop` `qa_review` handoffs stay inside the active current batch.
- Add state-aware QA artifact requirements: outcome, artifact evidence, repair direction status, root-cause classification, handoff target, and re-audit gate.
- Reinforce diagnosis-only ownership so QA does not edit runtime state, ledgers, planning artifacts, or manuscripts.

## Validation
- Pressure scenario review: current-batch fence approved
- Pressure scenario review: transition-critical QA artifact fields approved
- Pressure scenario review: diagnosis-only ownership approved
- `rg -n 'Orchestrator Handoff Intake|current_batch_start|current_batch_end|ready_next_slice|needs_recovery|blocked|Artifact evidence|Repair direction status|Classification: Root cause|Do not update `state/runtime.yaml`|handoff ledger alignment' skills/series-qa`
- `git diff --check`

Closes #11
