### PR TITLE
[codex] Harden longform design handoff rules

### DIFF
--- a/skills/longform-story-design/SKILL.md
+++ b/skills/longform-story-design/SKILL.md
@@ -16,6 +16,19 @@ Use this skill for series-level architecture, canon recovery, continuity control
 - Use `character-voice-bible` when the main problem is dialogue-only repair, register tuning, or cast-wide voice separation.
 - Keep canon extraction, recovery planning, and re-entry packet design here when the goal is to restore the longform structure rather than only describe the break.
 
+This skill owns planning and recovery artifacts only. Do not draft or rewrite scene/chapter prose here, and do not mutate `series-completion-loop` runtime files such as `state/runtime.yaml`, `state/active-slice.yaml`, or `state/handoff.md`. When called by an orchestrator, return artifacts and proof paths for the orchestrator to persist.
+
+## Orchestrator Handoff Intake
+
+When invoked by `series-completion-loop`, obey the current state boundary before choosing a general planning mode.
+
+- `slice_planning`: scope output to `current_batch_start` through `current_batch_end` only, normally the next `3~5화`.
+- `slice_planning`: create only the active-slice planning artifact needed for the next drafting handoff.
+- `slice_planning`: do not create or expand series architecture, future arcs, volume ladders, or later batches unless the handoff explicitly authorizes a broader planning mode.
+- `recovery_planning`: return a single recovery artifact suitable for `recovery/latest-recovery.md`.
+- `recovery_planning`: include root cause, repair order, next safe move, handoff target, must-not-break constraints, proof artifact path(s), and one exact re-entry slice.
+- `recovery_planning`: do not rewrite manuscript chapters, runtime state, or ledger files directly; name what must be updated and who owns it.
+
 ## Canonical Execution Order
 
 Lock decisions in this order: `mode -> package -> dominant risk -> stack -> depth -> drafting slice`.
@@ -150,6 +163,8 @@ Default stacks:
 - `recovery rebuild`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet
 - `continuity audit`: continuity ledger, knowledge-state tracker, payoff tracker, drafting packet
 
+When invoked for `series-completion-loop` `slice_planning`, override these general stacks with a current-batch slice packet only.
+
 Available deliverables:
 
 - series brief
@@ -195,6 +210,16 @@ For `recovery audit` and `recovery rebuild`, always end with a reusable planning
 - knowledge-state tracker
 - recovery plan
 - re-entry drafting packet
+
+When invoked for `series-completion-loop` `recovery_planning`, surface the recovery bundle as one top-level artifact for `recovery/latest-recovery.md`:
+
+- root cause
+- repair order
+- next safe move
+- handoff target
+- must-not-break constraints
+- proof artifact path(s)
+- re-entry slice with exact chapter, arc, or volume range
 
 Minimum recovery rules:
 
@@ -300,7 +325,7 @@ When the user wants actual scenes or chapters:
 1. finish or update the longform planning artifacts here
 2. if cast voice or dialogue differentiation is a visible risk, hand the dialogue layer to `character-voice-bible`
 3. hand narration, scene execution, and chapter prose to `novel-writing`
-4. after drafting, update continuity, knowledge state, and payoff status
+4. after drafting, record which continuity, knowledge-state, and payoff trackers must be updated; do not mutate orchestrator runtime state
 
 Use this skill before drafting when the manuscript is likely to drift. Use it after drafting when accumulated chapters need coherence repair.
 

--- a/skills/longform-story-design/agents/openai.yaml
+++ b/skills/longform-story-design/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Longform Story Design"
   short_description: "Planning and continuity architecture for Korean long-form fiction."
-  default_prompt: "Use $longform-story-design to build scalable Korean series architecture, repair long-draft drift, and prepare continuity-safe arc, volume, and chapter-range design packets."
+  default_prompt: "Use $longform-story-design to build bounded Korean longform planning or recovery artifacts, including series-completion-loop slice/recovery handoffs, without drafting prose or mutating runtime state."

--- a/skills/longform-story-design/references/handoff-to-drafting.md
+++ b/skills/longform-story-design/references/handoff-to-drafting.md
@@ -8,6 +8,8 @@ Do not pass the whole bible into every chapter draft. Reduce the planning layer 
 
 The active repaired slice should usually be one chapter or one short chapter range, one focal pressure, and one clear emotional or practical turn. If the next safe unit is larger than that, define why it must stay contiguous.
 
+If the caller is `series-completion-loop` `slice_planning`, the active repaired slice is exactly `current_batch_start` through `current_batch_end`, normally the next `3~5화`, and nothing beyond it.
+
 Reduce the planning layer to:
 
 - current arc purpose
@@ -42,6 +44,16 @@ Continuity constraints:
 Do not contradict:
 ```
 
+For orchestrated handoff, also include:
+
+```text
+Current batch:
+Proof artifact path(s):
+Handoff target:
+Next state suggestion:
+Must not plan beyond:
+```
+
 ## After Drafting
 
 After a draft batch exists, update:
@@ -51,6 +63,8 @@ After a draft batch exists, update:
 - revealed or newly suspected information
 - injuries, items, or travel state
 - payoff tracker status
+
+When called as an orchestrated specialist, return these tracker update requirements in the packet instead of directly editing runtime state or manuscript files.
 
 If the packet covered multiple chapters or multiple POVs, update each affected chapter or POV state separately so the next packet does not flatten them into one generic follow-up.
 

--- a/skills/longform-story-design/references/longform-workflow.md
+++ b/skills/longform-story-design/references/longform-workflow.md
@@ -14,7 +14,7 @@ Use this file when the user needs the full planning order for a long novel or se
 8. Break each major arc into chapter-range objectives.
 9. Create continuity, knowledge, and payoff trackers.
 10. Hand off only the active subset to drafting.
-11. After each drafting batch, update the trackers.
+11. After each drafting batch, record tracker update requirements or update only planning artifacts you own; never mutate orchestrator runtime state.
 
 ## Stage Exit Criteria
 
@@ -96,6 +96,8 @@ If the user brings broken chapters, conflicting outlines, or a draft that no lon
 3. separate timeline damage from motivation damage, knowledge damage, and payoff damage
 4. choose the smallest recovery bundle that clears the first blocking contradiction
 5. repair the active slice before expanding anything else
+
+When this flow is invoked by `series-completion-loop`, keep recovery inside the current failed slice unless proof shows the first break point predates it. Do not expand into future batches while building the recovery package.
 
 Use this recovery bundle order:
 

--- a/skills/longform-story-design/references/planning-output-format.md
+++ b/skills/longform-story-design/references/planning-output-format.md
@@ -104,6 +104,8 @@ Include:
 - drafting packet
 - continuity or payoff trackers if relevant
 
+If the caller supplies an active batch boundary, treat that boundary as the outer limit. The chapter-range plan must cover only the current batch and must not pre-plan later ranges beyond what is needed to maintain continuity.
+
 ## Density Rules
 
 Keep artifact density high but not bloated:
@@ -114,6 +116,8 @@ Keep artifact density high but not bloated:
 - core cast matrix: 1 block per major cast member
 - volume ladder: 3 to 7 entries for planned scale
 - chapter-range plan: one row or block per range, not per chapter unless requested
+
+For `series-completion-loop` `slice_planning`, density is capped by the current `3~5화` batch even when the whole project is 150~200 chapters.
 
 Genre-specific density shifts:
 

--- a/skills/longform-story-design/references/planning-stack-selection.md
+++ b/skills/longform-story-design/references/planning-stack-selection.md
@@ -14,6 +14,10 @@ Project state wins when it clearly says the work is greenfield, rolling, repair,
 
 When there is still a tie, choose the smaller stack that covers the first blocking problem. Do not add a document just because the project is large if a smaller recovery or drafting bundle already covers the next safe step.
 
+## Orchestrated Slice Rule
+
+When the caller is `series-completion-loop` in `slice_planning`, ignore scale-based expansion stacks beyond the active batch. Select only the smallest packet needed to plan `current_batch_start` through `current_batch_end`, normally the next `3~5화`, and carry forward no future-batch commitments.
+
 ## By Project State
 
 - premise only: story engine sheet, series brief, story bible
@@ -40,6 +44,8 @@ If more than one risk applies, choose the one that would break the next handoff 
 - under 40 chapters: story engine sheet, series brief, story bible, first arc plan
 - 40 to 120 chapters: story engine sheet, story bible, cast matrix, volume or arc plan, continuity ledger
 - 120 plus chapters or open serialization: story engine sheet, story bible, cast matrix, series expansion map, volume plan, chapter-range plan, continuity ledger, knowledge-state tracker, payoff tracker
+
+Do not apply the scale expansion rule to an orchestrated `slice_planning` handoff unless the handoff explicitly re-authorizes series-level planning.
 
 If scale points to a larger stack but the project state is still greenfield, do not start with continuity tools. If scale points to a smaller stack but the project is already in active drafting or repair, keep the drafting or recovery tools that match the current state.
 

--- a/skills/longform-story-design/references/repair-existing-draft.md
+++ b/skills/longform-story-design/references/repair-existing-draft.md
@@ -42,6 +42,18 @@ When repairing, prefer this bundle:
 - revised active arc plan if the middle has lost direction
 - drafting packet for the next safe chapter range
 
+For `series-completion-loop` `recovery_planning`, compress the bundle into one `recovery/latest-recovery.md` artifact with:
+
+- root cause
+- repair order
+- next safe move
+- handoff target
+- must-not-break constraints
+- proof artifact path(s)
+- re-entry slice with exact chapter, arc, or volume range
+
+Do not directly rewrite manuscript chapters, runtime state, or ledger entries. Return canon, continuity, and re-entry artifacts for the orchestrator and downstream owners.
+
 ## Decision Rule
 
 If two existing documents disagree, prefer the manuscript over notes unless the user explicitly says the notes supersede the draft.


### PR DESCRIPTION
## Summary
- Harden `longform-story-design` so `series-completion-loop` `slice_planning` stays inside the active `3~5화` batch.
- Add a concrete `recovery_planning` artifact contract for `recovery/latest-recovery.md`, including proof paths and exact re-entry slice.
- Reinforce ownership boundaries: no prose drafting, no manuscript rewrites, no runtime-state mutation, and no direct ledger rewrites outside returned artifacts.

## Validation
- Pressure scenario review: slice_planning scope leak approved
- Pressure scenario review: recovery artifact contract approved
- Pressure scenario review: ownership boundary approved
- `rg -n 'Orchestrator Handoff Intake|slice_planning|recovery_planning|current_batch_start|current_batch_end|3~5화|recovery/latest-recovery.md|Proof artifact|proof artifact|runtime state|Do not directly rewrite|Must not plan beyond|scale expansion' skills/longform-story-design`
- `git diff --check`

Closes #13
