### PR TITLE
[codex] Harden novel writing drafting handoff

### DIFF
--- a/skills/novel-writing/SKILL.md
+++ b/skills/novel-writing/SKILL.md
@@ -25,6 +25,38 @@ If the request says `써줘`, `초고`, `개고`, `원고`, `장면`, `챕터`, 
 Do not stop to ask broad process questions if a narrow assumption will let you proceed safely.
 If information is missing, make one-line assumptions and continue.
 
+## Orchestrator Drafting Intake
+
+When invoked by `series-completion-loop` for a `drafting` state, act only as the manuscript specialist for the current batch.
+
+Before drafting, require these handoff fields or stop with a blocker for the orchestrator:
+
+- selected `projects/<series-slug>/` runtime path
+- `current_batch_start`
+- `current_batch_end`
+- matching active-slice range, goal, POV, active cast, `must_keep`, and `must_not_break`
+- relevant current ledgers or prior manuscript excerpt needed to draft this batch safely
+
+For orchestrated drafting, hard-limit scope to `current_batch_start` through `current_batch_end`.
+
+- Draft only the active `3~5화` batch unless the handoff explicitly names a smaller current repair range.
+- Do not continue into future chapters, next slices, epilogues, or whole-series completion.
+- Do not invent missing runtime, slice, ledger, or project identity from chat context.
+- If the requested batch needs new macro planning, recovery direction, continuity repair, or QA judgment before prose can be safely written, stop and return a directional blocker instead of drafting around it.
+- Use `longform-story-design` for slice or recovery planning, `series-qa` for QA/continuity review, and `character-voice-bible` for dialogue-only voice repair.
+
+Write manuscript artifacts only. Do not edit `state/runtime.yaml`, `state/active-slice.yaml`, `state/handoff.md`, `ledger/continuity.md`, `ledger/knowledge-state.md`, `ledger/payoff-tracker.md`, `qa/latest-report.md`, or `recovery/latest-recovery.md`. The orchestrator records state after this skill returns.
+
+For a successful orchestrated batch, return `원고` by default and include a compact handoff summary with:
+
+- `batch_range`
+- `stage_files` for `초고`, `개고`, and `원고`
+- `latest_manuscript_batch` pointing to the final `원고` artifact for this batch
+- chapters actually drafted
+- assumptions used
+- continuity notes limited to current-batch exit state and unresolved items, not future-batch plotting
+- next handoff target, usually `series-qa`
+
 ## Default Assumptions When The User Omits Details
 
 Use these defaults so the skill remains executable for lightweight models:
@@ -38,8 +70,11 @@ Use these defaults so the skill remains executable for lightweight models:
 - tone: contemporary commercial Korean fiction matched to the requested genre
 - assumption policy: prefer the smallest assumption set that does not distort the user's premise
 
+Do not use these defaults to fill missing orchestrator batch fields. In a `series-completion-loop` drafting handoff, missing runtime path or batch range is a blocker, not an invitation to infer scope.
+
 If the environment supports file writing, save stage files.
 If the environment does not support file writing, still perform the same internal stage pipeline and return the final stage text.
+Exception: orchestrated drafting requires saved artifacts for state evidence. If stage files cannot be written during a `series-completion-loop` drafting handoff, return a blocker instead of reporting success.
 
 ## Overview
 
@@ -125,6 +160,7 @@ When the user asks for a scene, opening, chapter, or direct prose revision:
 6. Run a final manuscript quality gate before replying.
 
 If the user asks for multiple chapters, outline each chapter first, then draft in sequence so continuity does not drift.
+If the multi-chapter request is an orchestrated drafting handoff, the outline may cover only the active batch and must not seed future-batch prose.
 
 When the request is actual prose rather than advice only, read [references/draft-pipeline.md](references/draft-pipeline.md) and [references/manuscript-quality-gate.md](references/manuscript-quality-gate.md).
 If the user explicitly names a stage such as `초고`, `개고`, or `원고`, honor that as the return target. Otherwise, return `원고`.
@@ -185,6 +221,8 @@ When critiquing, point to concrete breaks in cause-and-effect, character logic, 
 
 - Prefer production-usable output over lecture-style explanation.
 - Summarize assumptions before long-form drafting.
+- For orchestrated drafting, treat `current_batch_start` and `current_batch_end` as a hard fence, not as a suggestion.
+- For orchestrated drafting, write only manuscript stage files and return paths; leave runtime, handoff, ledger, QA, and recovery files to their owning skills.
 - Preserve the user's chosen genre conventions unless they ask to subvert them.
 - Track named entities, timeline markers, unresolved promises, and scene exits while drafting.
 - When continuing an existing manuscript, mirror established POV, tense, diction, and paragraph density before introducing changes.
@@ -236,3 +274,4 @@ When replying, keep the structure aligned to the lane:
 - critique-only: concrete issue list first, rewrite only if asked
 
 When prose was generated in a writable environment, mention where `초고`, `개고`, and `원고` were saved.
+When prose was generated from an orchestrated drafting handoff, also mention the exact batch range and the `latest_manuscript_batch` path the orchestrator should record.

--- a/skills/novel-writing/agents/openai.yaml
+++ b/skills/novel-writing/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Novel Writing"
   short_description: "Narration-first Korean fiction drafting and prose revision."
-  default_prompt: "Use $novel-writing for Korean fiction planning, narration-heavy scene and chapter drafting, prose revision, and 초고/개고/원고 production. Route the request first, make minimal assumptions, load only the needed references, and if prose is requested execute 초고 -> 개고 -> 원고 and return 원고 by default."
+  default_prompt: "Use $novel-writing for Korean fiction planning, narration-heavy scene and chapter drafting, prose revision, and 초고/개고/원고 production. Route the request first, make minimal assumptions, load only the needed references, and if prose is requested execute 초고 -> 개고 -> 원고 and return 원고 by default. For series-completion-loop drafting handoffs, require current_batch_start/current_batch_end, draft only that batch, save stage files, and return artifact paths without editing runtime, handoff, ledger, QA, or recovery state."
 
 policy:
   allow_implicit_invocation: true

--- a/skills/novel-writing/references/draft-pipeline.md
+++ b/skills/novel-writing/references/draft-pipeline.md
@@ -8,6 +8,7 @@ Make `초고 -> 개고 -> 원고` the default internal pipeline for fiction writ
 
 The user should be able to open and edit every stage file directly.
 If file writing is unavailable in the current environment, still run the same three-stage pipeline internally and return the requested stage text instead of stopping.
+Exception: for `series-completion-loop` drafting handoffs, file writing is required because the orchestrator needs artifact paths. If stage files cannot be saved, return a blocker instead of a successful draft handoff.
 
 ## Folder Structure
 
@@ -37,6 +38,30 @@ Examples:
 
 If the user gives a title or chapter id, reflect it in the slug.
 If revising an existing set, keep the stem and add a short revision suffix only when necessary, such as `-r2`.
+For orchestrated batch drafting, include the batch range in the slug when possible, such as `ch012-014-current-batch.md`.
+
+## Orchestrated Batch Scope
+
+When `series-completion-loop` sends a drafting handoff, the stage pipeline is still mandatory, but the scope is narrower and stricter.
+
+Required before writing:
+
+- selected `projects/<series-slug>/` runtime path
+- `current_batch_start`
+- `current_batch_end`
+- matching active-slice range, goal, POV, active cast, `must_keep`, and `must_not_break`
+
+If any required field is missing or contradictory, do not invent it. Return a blocker for the orchestrator.
+
+Scope rules:
+
+- write only chapters inside `current_batch_start` through `current_batch_end`
+- do not draft future chapters, next batches, epilogues, or whole-series continuation
+- keep continuity notes limited to current-batch exit state and unresolved items; do not plan next-batch beats
+- do not update runtime, handoff, ledger, QA, or recovery files directly
+- if planning, continuity repair, recovery direction, or QA is needed first, stop and name the correct handoff target
+
+The saved stage files are the evidence the orchestrator records afterward.
 
 ## Stage Rules
 
@@ -113,6 +138,7 @@ At the top of each saved stage file, include a short header:
 ```
 
 Keep the header short. The prose should start immediately after it.
+For orchestrated batches, the `scope` line must include the exact batch range, for example `scope: ch012-ch014 current batch`.
 
 ## When Revising Existing User Text
 
@@ -131,3 +157,4 @@ In the final response:
 - mention that the files were saved
 - provide the saved stage file path and, when helpful, the `초고`, `개고`, and `원고` file paths
 - summarize the main difference between stages in one short sentence
+- for orchestrated drafting, include `batch_range`, `chapters_drafted`, `stage_files`, `latest_manuscript_batch`, assumptions, continuity notes, and next handoff target for the orchestrator

--- a/skills/novel-writing/references/manuscript-quality-gate.md
+++ b/skills/novel-writing/references/manuscript-quality-gate.md
@@ -28,7 +28,22 @@ Before final cleanup, confirm that the draft still has:
 
 If any item is missing, fix structure before polishing sentences.
 
-## 3. Run The Dialogue Check
+## 3. Confirm Orchestrated Batch Fence
+
+Apply this section only when the draft came from a `series-completion-loop` drafting handoff.
+
+Before final cleanup, confirm that:
+
+- every drafted chapter is within `current_batch_start` and `current_batch_end`
+- no future batch, next-slice teaser chapter, epilogue, or whole-series continuation was drafted
+- continuity notes describe only current-batch exit state and unresolved items, not next-batch plot beats
+- `초고`, `개고`, and `원고` share one ASCII file stem
+- final response includes `stage_files` and `latest_manuscript_batch`
+- runtime, handoff, ledger, QA, and recovery files were not edited by this skill
+
+If any item fails, revise the output back inside the active batch or return a blocker to the orchestrator.
+
+## 4. Run The Dialogue Check
 
 Check each exchange for:
 
@@ -41,7 +56,7 @@ Check each exchange for:
 
 If a line sounds semantically correct but not speakable, rewrite the turn rather than trimming words mechanically.
 
-## 4. Run The Narration Check
+## 5. Run The Narration Check
 
 Check narration for:
 
@@ -53,7 +68,7 @@ Check narration for:
 
 If a sentence feels meaning-first, rebuild it from image, pressure, or viewpoint rather than line-editing the surface.
 
-## 5. Compare Stage Separation
+## 6. Compare Stage Separation
 
 Verify that each stage does different work:
 
@@ -63,7 +78,7 @@ Verify that each stage does different work:
 
 If `원고` is only a lightly reformatted `개고`, revise again before replying.
 
-## 6. Final Release Rules
+## 7. Final Release Rules
 
 Before returning the draft:
 
@@ -74,3 +89,4 @@ Before returning the draft:
 - ensure no awkward wording exists only because a common Sino-Korean term was forcibly replaced
 
 Return `원고` by default. If the user explicitly asked for `초고` or `개고`, return that requested stage instead and mention the saved stage file paths.
+For orchestrated drafting, also return the batch range, chapters drafted, `stage_files`, `latest_manuscript_batch`, assumptions, continuity notes, and next handoff target.

--- a/skills/novel-writing/references/task-router.md
+++ b/skills/novel-writing/references/task-router.md
@@ -61,6 +61,12 @@ Optional:
 - [chapter-opening-selection.md](chapter-opening-selection.md) for opener requests
 - [starter-sets.md](starter-sets.md) for chapter 1 or subgenre-specific launch requests
 
+Orchestrated handoff rule:
+
+- if `series-completion-loop` hands off `drafting`, treat it as fresh drafting only inside `current_batch_start` through `current_batch_end`
+- do not infer missing runtime or batch range
+- do not draft future chapters or update runtime, handoff, ledger, QA, or recovery artifacts
+
 ### 3. Continuation
 
 Use when the user asks for:

--- a/skills/novel-writing/references/templates.md
+++ b/skills/novel-writing/references/templates.md
@@ -82,6 +82,8 @@ Exit condition / cliff:
 Continuity notes for next chapter:
 ```
 
+When filling this template for an orchestrated `series-completion-loop` drafting handoff, use the continuity note line only for current-batch exit state and unresolved items. Do not add next-batch plot beats or future-slice plans.
+
 ## Scene Card
 
 ```text

--- a/skills/novel-writing/references/workflow.md
+++ b/skills/novel-writing/references/workflow.md
@@ -16,6 +16,7 @@ Capture the minimum brief:
 - current manuscript state
 
 If critical information is missing, state a narrow assumption set and proceed.
+Exception: for a `series-completion-loop` drafting handoff, missing selected runtime path, `current_batch_start`, `current_batch_end`, or active-slice range is a blocker. Do not infer those fields from chat context.
 
 Before loading deeper references, classify the request with [task-router.md](task-router.md) if the lane is not obvious.
 Pick one primary lane: planning, fresh drafting, continuation, stage revision, dialogue-only revision, narration-only revision, or critique-only.
@@ -47,6 +48,17 @@ If you need concrete diction replacements for this issue, load [lexical-normaliz
 - dialogue-only revision: delegate to `character-voice-bible`; only use [dialogue-revision-selection.md](dialogue-revision-selection.md) as fallback if that skill is unavailable
 - narration-only revision: load [narration-revision-selection.md](narration-revision-selection.md) and only load manuscript-mode references if the user wants full prose output
 - critique-only: diagnose concrete issues first; do not rewrite unless the user asks
+
+### Orchestrated Drafting Handoff
+
+Use this wrapper when `series-completion-loop` hands off a `drafting` state.
+
+- Treat the primary lane as fresh drafting or stage revision, but hard-limit it to `current_batch_start` through `current_batch_end`.
+- Draft only the active `3~5화` batch or explicitly smaller repair range named by the handoff.
+- Load [draft-pipeline.md](draft-pipeline.md) and [manuscript-quality-gate.md](manuscript-quality-gate.md) before prose work.
+- Save `초고`, `개고`, and `원고` with one shared ASCII stem and batch-range metadata.
+- Return stage file paths and manuscript notes; do not edit `state/runtime.yaml`, `state/handoff.md`, ledgers, QA reports, or recovery plans.
+- Stop instead of drafting when the handoff actually needs slice planning, recovery planning, QA, or dialogue-only voice repair.
 
 ## 2. Stabilize The Story Engine
 
@@ -97,6 +109,11 @@ When writing prose in this workspace, default to:
 5. run the final manuscript quality gate
 6. save all three files
 7. return the `원고` version by default, or the explicitly requested stage if the user named one
+
+For orchestrated drafting, add two release checks before returning:
+
+- no chapter outside the active batch was drafted or previewed
+- the response names `latest_manuscript_batch` as the final `원고` artifact path the orchestrator should record
 
 ## 5. Revise In Separate Passes
 


### PR DESCRIPTION
## Summary
- Add a novel-writing orchestrator drafting intake for current-batch handoffs from series-completion-loop.
- Require current_batch_start/current_batch_end plus matching active-slice context before drafting.
- Return stage_files and latest_manuscript_batch evidence while forbidding runtime, handoff, ledger, QA, and recovery mutation.
- Keep continuity notes limited to current-batch exit state and unresolved items, not future-batch plotting.

## Validation
- Pressure-tested Scenario A: active-batch fence and future-batch prevention: PASS.
- Pressure-tested Scenario B: stage files and latest_manuscript_batch evidence: PASS.
- Pressure-tested Scenario C: ownership boundaries and metadata prompt: PASS.
- Ran `rg` checks for handoff guardrail terms across skills/novel-writing.
- Ran `git diff --check`.

Closes #15
