### PR TITLE
[codex] Harden character voice handoff

### DIFF
--- a/skills/character-voice-bible/SKILL.md
+++ b/skills/character-voice-bible/SKILL.md
@@ -11,6 +11,46 @@ Use this skill to build and maintain a cast-wide Korean dialogue system. Focus o
 
 Default to dialogue-first execution. If the user wants active exchange, output speaker-labeled lines that read like a script before considering prose wrapping. Keep the center of gravity on what the characters say, how they react, and how their spoken turns collide.
 
+## Orchestrated Voice Handoff Intake
+
+When invoked by `series-completion-loop`, `novel-writing`, or `series-qa` for dialogue repair, act only as the voice specialist for the current batch or excerpt.
+
+Before voice work, require the handoff to name:
+
+- selected `projects/<series-slug>/` runtime path or explicit manuscript artifact path
+- `current_batch_start` and `current_batch_end`, or a smaller explicit excerpt/range inside that batch
+- affected speakers or pair/group
+- current relationship state and register expectation
+- scene pressure or voice failure being repaired
+- existing dialogue lines, or a clear request for sample proof lines only
+
+If the orchestrated handoff lacks batch/excerpt scope, affected speakers, or current relationship state, return a blocker. Do not infer project identity, batch range, future relationship state, or missing plot context from chat history.
+
+Hard-limit orchestrated voice work to the named batch or excerpt.
+
+- Repair only dialogue, speaker differentiation, register, address forms, and voice rules.
+- Do not continue the chapter, write narration-heavy prose, draft new scenes, plan future chapters, or redesign plot beats.
+- Do not mutate manuscript stage files directly; return proof rewrites for the caller to apply.
+- Do not edit `state/runtime.yaml`, `state/active-slice.yaml`, `state/handoff.md`, ledgers, QA reports, recovery plans, or `초고`/`개고`/`원고` files.
+- If the handoff needs plot planning, recovery direction, QA acceptance, continuity ledger repair, or full prose integration, stop and name the correct owner: `longform-story-design`, `series-qa`, or `novel-writing`.
+
+For successful orchestrated voice work, return a compact `voice_handoff` block with:
+
+- `source_artifact`
+- `batch_range`
+- `excerpt_range`
+- `affected_speakers`
+- `relationship_state`
+- `voice_failure`
+- `repair_rules`
+- `proof_rewrites` with original line references or before/after mapping
+- `register_notes`
+- `assumptions`
+- `unresolved_voice_risks`
+- `next_handoff_target`, usually `novel-writing` for prose integration or `series-qa` for review
+
+The `voice_handoff` block is the handoff artifact. If it must be persisted, the caller or orchestrator saves it; this skill should not write runtime or manuscript files during an orchestrated handoff.
+
 ## Assume Script-First Mode For Dialogue Requests
 
 When the user asks for lines that feel like actors are trading dialogue, treat that as the default mode for this skill.
@@ -66,6 +106,7 @@ Lock the minimum evidence before designing voice:
 - the scene pressure that reveals the voice failure
 
 If the user does not provide enough information, infer only what is structurally safe and label the assumption. Do not invent ornamental quirks to fill gaps.
+Exception: for orchestrated voice handoffs, missing batch/excerpt scope, affected speakers, or current relationship state is a blocker, not a safe assumption.
 
 For fast diagnostic prompts, read [references/voice-diagnostic-questions.md](references/voice-diagnostic-questions.md).
 
@@ -229,11 +270,12 @@ Choose the output that matches the request:
 - micro voice sheet
 - composition recipe
 - rewrite rules for future chapters
+- orchestrated `voice_handoff`
 
 Prefer compact tables and bullet rules over abstract theory.
 Always include enough concrete proof that another Codex instance could apply the result without re-deriving the logic.
 
-Unless the user explicitly asks for prose, keep outputs diagnostic and operational:
+Unless the user explicitly asks for prose outside an orchestrated handoff, keep outputs diagnostic and operational:
 
 - identify the failure
 - state the repair rule
@@ -241,7 +283,10 @@ Unless the user explicitly asks for prose, keep outputs diagnostic and operation
 - prefer speaker-labeled turns over narrated explanation
 - end with guardrails for future chapters
 
+For orchestrated voice work, keep future guardrails limited to reusable voice rules. Do not include future-batch plot beats, next-scene instructions, or unresolved-story planning.
+
 If the user asks for scene or chapter prose, use this skill to define the voices first, then hand off narration, scene blocking, and prose execution to `novel-writing`.
+In orchestrated handoffs, even explicit prose pressure should be reduced to voice rules and proof rewrites, then handed to `novel-writing` for integration.
 
 ## Operating Rules
 
@@ -254,6 +299,7 @@ If the user asks for scene or chapter prose, use this skill to define the voices
 - When revising, preserve scene intent and information flow before beautifying the line.
 - If a line sounds distinct only because of a gimmick phrase, rebuild the underlying reaction pattern.
 - Do not drift into narration-heavy scene polish when the user's real need is spoken-line control.
+- For orchestrated voice handoffs, return repair guidance and proof rewrites only; leave manuscript editing, runtime updates, QA acceptance, and recovery planning to their owning skills.
 
 ## Relationship To Other Skills
 

--- a/skills/character-voice-bible/agents/openai.yaml
+++ b/skills/character-voice-bible/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Character Voice Bible"
   short_description: "Dialogue-first Korean character voice design and drift repair."
-  default_prompt: "Use $character-voice-bible for dialogue-only revision, speaker differentiation, relationship-based register control, or line-by-line Korean spoken exchange design."
+  default_prompt: "Use $character-voice-bible for dialogue-only revision, speaker differentiation, relationship-based register control, or line-by-line Korean spoken exchange design. For orchestrated handoffs, require current batch or excerpt scope, return a compact voice_handoff with repair rules and proof rewrites, and do not edit manuscript, runtime, handoff, ledger, QA, or recovery state."

--- a/skills/character-voice-bible/references/composition-guide.md
+++ b/skills/character-voice-bible/references/composition-guide.md
@@ -185,3 +185,4 @@ Stop loading files once you can answer these five questions:
 - What setting texture must stay audible?
 
 If all five are answerable, write the dialogue.
+For orchestrated voice handoffs, this means write only bounded proof rewrites or sample turns for the named excerpt. Do not add new scene beats, continue the chapter, or expand beyond the supplied range.

--- a/skills/character-voice-bible/references/dialogue-drift-checks.md
+++ b/skills/character-voice-bible/references/dialogue-drift-checks.md
@@ -26,6 +26,9 @@ For each issue, note:
 - minimal repair
 - future guardrail
 
+For orchestrated handoffs, include the active batch or excerpt range and keep `future guardrail` to reusable voice behavior. Do not add future-batch plot beats, scene continuation, QA acceptance, or recovery direction.
+Proof rewrites in orchestrated handoffs should include original line references or a before/after mapping so the caller can apply them without guessing.
+
 ## Minimal Repair Strategy
 
 Fix in this order:

--- a/skills/character-voice-bible/references/output-templates.md
+++ b/skills/character-voice-bible/references/output-templates.md
@@ -2,6 +2,32 @@
 
 Use this file when you need compact, reusable output shapes.
 
+## Orchestrated Voice Handoff
+
+```text
+voice_handoff
+
+source_artifact:
+batch_range:
+excerpt_range:
+affected_speakers:
+relationship_state:
+voice_failure:
+repair_rules:
+- rule
+proof_rewrites:
+- original_ref:
+  before:
+  after:
+  reason:
+register_notes:
+assumptions:
+unresolved_voice_risks:
+next_handoff_target:
+```
+
+Use this only for orchestrated handoffs from `series-completion-loop`, `novel-writing`, or `series-qa`. Keep it limited to dialogue and voice repair. The block is the handoff artifact; the caller may persist it. Do not include future-batch plot beats, narration-heavy prose, manuscript stage-file edits, runtime updates, QA acceptance, or recovery planning.
+
 ## Cast Voice Bible
 
 ```text
@@ -77,6 +103,8 @@ Minimal repair:
 One proof rewrite:
 Future guardrail:
 ```
+
+For orchestrated handoffs, `Future guardrail` means a reusable voice rule only, not a future chapter or plot instruction.
 
 ## Dialogue Exchange Sheet
 

--- a/skills/character-voice-bible/references/request-router.md
+++ b/skills/character-voice-bible/references/request-router.md
@@ -2,6 +2,38 @@
 
 Use this file to choose the smallest useful deliverable and the smallest reference set.
 
+## Orchestrated Handoff Route
+
+When `series-completion-loop`, `novel-writing`, or `series-qa` sends a dialogue or voice repair handoff, route to `orchestrated voice_handoff`.
+
+Required scope:
+
+- current batch range or explicit excerpt/range
+- affected speakers or pair/group
+- current relationship state
+- scene pressure or visible voice failure
+
+If any required scope is missing, return a blocker. Do not infer batch range, relationship progression, or plot context.
+
+Allowed output:
+
+- source artifact or excerpt reference
+- batch range and excerpt range as separate fields when available
+- repair rules
+- proof rewrites with original-to-rewrite mapping
+- register notes
+- assumptions
+- unresolved voice risks
+- next handoff target
+
+Forbidden output:
+
+- future-batch plot beats
+- narration-heavy prose
+- chapter continuation
+- direct manuscript or stage-file mutation
+- runtime, ledger, QA, recovery, or stage-file edits
+
 ## Route By User Intent
 
 Start with `composition-guide.md` whenever the request clearly combines more than one axis.
@@ -80,3 +112,4 @@ Do not build a full cast bible when the user only needs:
 - one pair separated
 
 Expand scope only if the localized failure clearly comes from missing cast-wide rules.
+For orchestrated voice handoffs, expansion can only widen voice rules inside the active batch or excerpt. Broader planning, recovery, or prose execution belongs to the caller or another specialist.

--- a/skills/character-voice-bible/references/voice-design-workflow.md
+++ b/skills/character-voice-bible/references/voice-design-workflow.md
@@ -13,6 +13,8 @@ Use this file when the user needs the full order for designing or repairing a ca
 7. Audit sample dialogue and repair drift.
 8. Deliver reusable rules for future drafting.
 
+For orchestrated handoffs, "future drafting" means voice rules for the caller to apply, not future-batch plot or manuscript continuation.
+
 ## Start From The Smallest Useful Cast
 
 Do not profile the whole ensemble by default. Prioritize:
@@ -54,3 +56,5 @@ When revising accumulated chapters:
 3. separate overlapping reaction styles
 4. restore pressure-based line movement
 5. update voice rules for future chapters
+
+For orchestrated handoffs, stop at voice rules and proof rewrites. Do not edit accumulated manuscript files, runtime state, continuity ledgers, QA reports, or recovery plans directly.


### PR DESCRIPTION
## Summary
- Add an orchestrated voice handoff intake for character-voice-bible.
- Require current batch or explicit excerpt scope, affected speakers, relationship state, and visible voice failure before repair.
- Return a stable voice_handoff schema with source/range, repair rules, proof rewrite mappings, assumptions, unresolved risks, and next handoff target.
- Forbid future-batch plotting, chapter continuation, narration-heavy prose, direct manuscript/stage edits, runtime/handoff/ledger/QA/recovery mutation.

## Validation
- Pressure-tested Scenario A: current-batch/excerpt fence and no future expansion: PASS.
- Pressure-tested Scenario B: machine-usable voice_handoff schema: PASS.
- Pressure-tested Scenario C: ownership and mutation boundaries: PASS.
- Ran `rg` checks for handoff guardrail terms across skills/character-voice-bible.
- Ran `git diff --check`.

Closes #17
