### PR TITLE
[codex] Validate series specialist returns

### DIFF
--- a/projects/_template/state/runtime.yaml
+++ b/projects/_template/state/runtime.yaml
@@ -13,3 +13,7 @@ last_run_at: null
 failure_count: 0
 blocked_reason: null
 last_completed_stage: null
+last_completed_transition: null
+last_artifact_pointer: null
+last_proof_predicate: null
+specialist_return_accepted: null

--- a/skills/series-completion-loop/SKILL.md
+++ b/skills/series-completion-loop/SKILL.md
@@ -41,6 +41,19 @@ The specialist owns the domain work product for the current state. The orchestra
 
 Scope every delegated task to `current_batch_start` through `current_batch_end`. Do not include future-slice material. Before and after each handoff, verify that `state/active-slice.yaml` still matches the current manuscript batch. If the batch boundary moved or next-slice work was pulled forward, stop at `blocked` or re-enter from the last valid boundary.
 
+## Specialist Return Validation
+Before updating `state/runtime.yaml`, `state/handoff.md`, or any artifact pointer after a specialist handoff, verify the returned evidence matches the current state and batch.
+
+Expected return evidence:
+
+- `longform-story-design` for `slice_planning`: active-slice content or artifact with `chapter_start`, `chapter_end`, `batch_goal`, `success_conditions`, `active_pov`, `active_cast`, `must_keep`, `must_not_break`, and `handoff_target`, with `chapter_start` and `chapter_end` matching `current_batch_start` and `current_batch_end`.
+- `longform-story-design` for `recovery_planning`: one recovery artifact suitable for `recovery/latest-recovery.md`, including root cause, repair order, next safe move, handoff target, must-not-break constraints, proof artifact path(s), and exact re-entry slice.
+- `novel-writing` for `drafting`: `batch_range`, `chapters_drafted`, `stage_files`, `latest_manuscript_batch`, assumptions, continuity notes, and next handoff target.
+- `series-qa` for `qa_review`: `qa/latest-report.md` or equivalent QA artifact with the reviewed batch range, outcome `ready_next_slice`, `needs_recovery`, or `blocked`, evidence, root cause when applicable, repair direction when applicable, re-audit gate, and handoff target.
+- `character-voice-bible` for dialogue repair: `voice_handoff` with `source_artifact`, `batch_range`, `excerpt_range`, `affected_speakers`, `relationship_state`, `voice_failure`, `repair_rules`, `proof_rewrites`, `register_notes`, assumptions, unresolved voice risks, and next handoff target.
+
+Treat validation failure as a transition blocker. If a specialist return is missing required fields, has present-but-empty or semantically invalid values, names chapters outside the current batch, includes future-batch work, lacks proof artifact paths, is schema-mismatched, or contradicts `state/active-slice.yaml`, do not normalize or repair it inline. Record the mismatch in `state/handoff.md`, keep or set `state: blocked` with `blocked_reason`, and re-enter from the last valid boundary.
+
 ## Canonical Loop Order
 Follow this order unless runtime state says a different valid transition is needed:
 
@@ -125,6 +138,10 @@ Do not stop a production run until `state/runtime.yaml` and `state/handoff.md` s
 - artifact paths created, reviewed, or accepted in the run
 - `last_run_at`
 - `last_completed_stage` or `blocked_reason`
+- `last_completed_transition`
+- `last_artifact_pointer`
+- `last_proof_predicate`
+- `specialist_return_accepted`
 
 When marking `completed` or `blocked`, name the exact predicate satisfied and the artifact path that proves it. If no proof exists, stay in the prior valid state or mark `blocked` rather than pretending the transition completed.
 
@@ -144,5 +161,6 @@ Block the run when:
 - QA fails twice on the same slice without a changed repair direction
 - recovery runs twice in a row without changing `state/active-slice.yaml` or `recovery/latest-recovery.md`
 - approval is bypassed in `approval-gated` mode
+- specialist return evidence is missing, out of batch, future-batch, schema-mismatched, semantically invalid, or contradicts the active slice
 
 On re-entry, set the next state explicitly, keep the manuscript intact, and continue only from the last valid boundary.

--- a/skills/series-completion-loop/agents/openai.yaml
+++ b/skills/series-completion-loop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Series Completion Loop"
   short_description: "State-based orchestration for long-running Korean fiction completion."
-  default_prompt: "Use $series-completion-loop only for an explicit projects/<series-slug>/ runtime. Move the project through the next valid 3~5화 bounded transition, delegate specialist work, update runtime and handoff evidence, and stop."
+  default_prompt: "Use $series-completion-loop only for an explicit projects/<series-slug>/ runtime. Move the project through the next valid 3~5화 bounded transition, delegate specialist work, validate required return evidence, update runtime and handoff evidence only after validation, and stop."

--- a/skills/series-completion-loop/references/automation-prompts.md
+++ b/skills/series-completion-loop/references/automation-prompts.md
@@ -8,6 +8,8 @@
 - read `state/runtime.yaml`
 - perform the next valid bounded action only
 - never draft, bootstrap, or reconstruct state from chat context
+- after any specialist handoff, validate required return evidence before updating runtime
+- if specialist evidence is missing, out of batch, future-batch, or schema-mismatched, set `state: blocked` with `blocked_reason`; report only when the selected runtime cannot be safely written
 - update `state/runtime.yaml`
 - update `state/handoff.md`
 - stop
@@ -20,6 +22,11 @@ Required closing fields:
 - `current_batch_end`
 - `last_run_at`
 - artifact path or reviewed artifact path
+- specialist return evidence accepted, or blocked mismatch evidence
+- `last_completed_transition`
+- `last_artifact_pointer`
+- `last_proof_predicate`
+- `specialist_return_accepted`
 - `last_completed_stage` or `blocked_reason`
 
 ## Safety Run
@@ -27,7 +34,8 @@ Required closing fields:
 - detect stalled `blocked`
 - detect missing QA after drafting
 - detect repeated recovery
-- report only
+- mark `state: blocked` when a block condition has exact evidence
+- report only when the selected runtime is missing, ambiguous, or not safely writable
 - do not force progress
 
-Safety runs may write only a status note to `state/handoff.md` unless they are marking an already-detected unsafe condition as `blocked` in `state/runtime.yaml`.
+Safety runs may write only the minimal `state/runtime.yaml` and `state/handoff.md` evidence needed to record `blocked`; otherwise they must report without changing project state.

--- a/skills/series-completion-loop/references/failure-reentry.md
+++ b/skills/series-completion-loop/references/failure-reentry.md
@@ -16,6 +16,7 @@ Block conditions:
 - approval bypass in `approval-gated` mode
 - active slice and actual manuscript range diverge
 - completion conditions are undefined while next-slice generation continues
+- specialist return evidence is missing, out of batch, future-batch, schema-mismatched, or contradicts the active slice
 
 Operational checks:
 
@@ -23,7 +24,7 @@ Operational checks:
 - ambiguous selected runtime means more than one `projects/<series-slug>/` path could plausibly match the request; do not choose from chat context
 - missing state means any required file is absent, or a required key is absent from the file that owns it
 - required `project.md` fields are Title, Slug, Target scale, Completion mode, Default batch size, and Ending promise
-- required `state/runtime.yaml` keys are `mode`, `state`, `next_action`, `approval_pending`, `last_approval_at`, `last_approval_batch_start`, `last_approval_batch_end`, `last_approval_note`, `current_batch_start`, `current_batch_end`, `latest_manuscript_batch`, `last_run_at`, `failure_count`, `blocked_reason`, and `last_completed_stage`
+- required `state/runtime.yaml` keys are `mode`, `state`, `next_action`, `approval_pending`, `last_approval_at`, `last_approval_batch_start`, `last_approval_batch_end`, `last_approval_note`, `current_batch_start`, `current_batch_end`, `latest_manuscript_batch`, `last_run_at`, `failure_count`, `blocked_reason`, `last_completed_stage`, `last_completed_transition`, `last_artifact_pointer`, `last_proof_predicate`, and `specialist_return_accepted`
 - required `state/active-slice.yaml` keys are `chapter_start`, `chapter_end`, `batch_goal`, `success_conditions`, `active_pov`, `active_cast`, `must_keep`, `must_not_break`, and `handoff_target`
 - contradictory state means the runtime `state` is not one of the approved states, `mode` is not `autonomous` or `approval-gated`, `current_batch_start` is greater than `current_batch_end`, `approval_pending: true` appears outside `approval_waiting`, `approval_pending: false` leaves `approval_waiting` without `last_approval_at` and matching approval batch fields, or `state: completed` still has a non-empty `next_action`
 - `failure_count >= 2` on the same `current_batch_start` and `current_batch_end` means the same slice has failed twice
@@ -32,6 +33,8 @@ Operational checks:
 - active-slice divergence means `state/active-slice.yaml` chapter range does not match the newest saved manuscript batch named in `state/runtime.yaml`
 - undefined completion means `project.md` has no ending promise, target scale, or completion condition while `next_action` is `slice_planning`
 - unproven stop means `state/runtime.yaml` or `state/handoff.md` lacks the artifact path or predicate that proves `completed`, `blocked`, or the completed transition; stay in the prior valid state or mark `blocked`
+- machine-checkable stop evidence means `last_completed_transition`, `last_artifact_pointer`, `last_proof_predicate`, and `specialist_return_accepted` are populated consistently with the state transition, or `blocked_reason` names why they cannot be accepted
+- specialist return mismatch means the returned planning packet, manuscript batch, QA report, recovery artifact, or `voice_handoff` lacks required fields, has present-but-empty or semantically invalid values, lacks proof paths, points outside `current_batch_start` through `current_batch_end`, is schema-mismatched, or asks the orchestrator to repair specialist output inline
 
 Recovery rules:
 

--- a/skills/series-completion-loop/references/runtime-layout.md
+++ b/skills/series-completion-loop/references/runtime-layout.md
@@ -37,8 +37,27 @@ Delegation rule:
 
 - pass only current-batch runtime context to specialist skills
 - specialists own prose, QA, dialogue, design, and recovery artifacts
-- after a specialist returns, the orchestrator updates only runtime, handoff, and artifact pointers
+- after a specialist returns, validate required return evidence before updating runtime, handoff, and artifact pointers
 - if specialist work would require the next batch, stop and hand off instead of extending scope
+
+Specialist return validation:
+
+| Specialist | State | Required return evidence before update |
+| --- | --- | --- |
+| `longform-story-design` | `slice_planning` | active-slice content or artifact with matching `chapter_start`/`chapter_end`, `batch_goal`, `success_conditions`, `active_pov`, `active_cast`, `must_keep`, `must_not_break`, and `handoff_target` |
+| `longform-story-design` | `recovery_planning` | one recovery artifact for `recovery/latest-recovery.md` with root cause, repair order, next safe move, handoff target, must-not-break constraints, proof artifact path(s), and exact re-entry slice |
+| `novel-writing` | `drafting` | `batch_range`, `chapters_drafted`, `stage_files`, `latest_manuscript_batch`, assumptions, continuity notes, and next handoff target |
+| `series-qa` | `qa_review` | QA artifact with reviewed batch range, outcome `ready_next_slice`/`needs_recovery`/`blocked`, evidence, root cause or repair direction when applicable, re-audit gate, and handoff target |
+| `character-voice-bible` | dialogue repair | `voice_handoff` with source artifact, batch/excerpt range, affected speakers, relationship state, voice failure, repair rules, proof rewrites, register notes, assumptions, risks, and next handoff target |
+
+If required evidence is missing, present but semantically invalid, out of batch, future-batch, schema-mismatched, or contradictory, write only the blocked reason and proof of mismatch to runtime/handoff. Do not advance to the next state.
+
+Runtime stop evidence fields:
+
+- `last_completed_transition`
+- `last_artifact_pointer`
+- `last_proof_predicate`
+- `specialist_return_accepted`
 
 | State | Read | Write |
 | --- | --- | --- |

--- a/skills/series-completion-loop/references/state-machine.md
+++ b/skills/series-completion-loop/references/state-machine.md
@@ -47,7 +47,10 @@ Stop evidence:
 
 - `state/runtime.yaml` records the completed transition, batch range, next state, next action, timestamp, and artifact pointer
 - `state/handoff.md` records what finished, what artifact proves it, and where the next run resumes
+- machine-checkable runtime fields are `last_completed_transition`, `last_artifact_pointer`, `last_proof_predicate`, and `specialist_return_accepted`
 - `completed` and `blocked` require the exact predicate and proof artifact path before the run may stop
+- after every specialist handoff, the state may advance only if required return evidence is present and matches the active batch
+- missing, out-of-batch, future-batch, or schema-mismatched specialist returns must use `* -> blocked`
 
 Mode-specific transition authority:
 


### PR DESCRIPTION
## Summary
- Add per-specialist return evidence gates before series-completion-loop updates runtime or handoff state.
- Require concrete evidence for active slices, manuscript batches, QA outcomes, recovery artifacts, and voice_handoff blocks.
- Block missing, out-of-batch, future-batch, schema-mismatched, semantically invalid, or contradictory specialist returns instead of normalizing or advancing.
- Add machine-checkable runtime stop evidence fields and align the project runtime template.
- Tighten production and safety automation prompts so invalid specialist evidence persists `state: blocked` when writable.

## Validation
- Pressure-tested Scenario A: per-specialist evidence gates: PASS.
- Pressure-tested Scenario B: invalid specialist returns block: PASS.
- Pressure-tested Scenario C: automation/runtime stop evidence alignment: PASS.
- Ran `rg` checks for return-validation guardrail terms across series-completion-loop and runtime template.
- Ran `git diff --check`.

Closes #19
