### PR TITLE
[codex] Enforce longform recovery rebuild

### DIFF
--- a/Platform/OpenAI/GPT-OSS/ROUTER.md
+++ b/Platform/OpenAI/GPT-OSS/ROUTER.md
@@ -108,6 +108,7 @@
 - 시리즈, 볼륨, 아크를 설계하고 싶다
 - 장르 패키지 선택이 모호하다
 - 연재가 길어지며 구조가 흔들린다
+- 손상된 장편 원고를 recovery audit 또는 recovery rebuild로 복구하고 싶다
 - 설정집, 연속성 문서, payoff tracker가 필요하다
 - drafting 전에 story engine을 먼저 세워야 한다
 
@@ -119,6 +120,8 @@
 - cast matrix
 - arc/volume plan
 - continuity ledger
+- recovery plan
+- re-entry drafting packet
 
 기본 참조 시작점:
 

--- a/Platform/OpenAI/GPT-OSS/SYSTEM_PROMPT.md
+++ b/Platform/OpenAI/GPT-OSS/SYSTEM_PROMPT.md
@@ -34,8 +34,9 @@
 - 명시된 `projects/<series-slug>/` 런타임을 다음 묶음으로 진행하는 요청이면 `series-completion-loop`를 우선한다.
 - 대사 자체가 문제면 `character-voice-bible`을 우선한다.
 - 서술, 나레이션, 장면 산문이 문제면 `novel-writing`을 우선한다.
-- 장기 구조와 시리즈 설계가 문제면 `longform-story-design`을 우선한다.
-- 기존 원고의 문제 분석, 진단 우선순위, handoff target 결정이 목적이면 `series-qa`를 우선한다.
+- 장기 구조, 시리즈 설계, recovery audit/recovery rebuild가 문제면 `longform-story-design`을 우선한다.
+- 기존 원고의 report-only QA, 진단 우선순위, handoff target 결정만 목적이면 `series-qa`를 우선한다.
+- 기존 원고에서 canon extraction, recovery plan, re-entry drafting packet이 필요하면 `longform-story-design`을 우선한다.
 - `series-completion-loop`는 직접 원고를 쓰거나 설계를 대신하지 않고, 필요한 전문 작업층으로 넘긴 뒤 런타임 증거를 갱신한다.
 - 복합 요청일 때는 한 번에 모든 층을 섞지 말고, 가장 상위의 병목을 먼저 해결한다.
 

--- a/Platform/OpenAI/GPT-OSS/skills/longform-story-design/SKILL.md
+++ b/Platform/OpenAI/GPT-OSS/skills/longform-story-design/SKILL.md
@@ -6,9 +6,12 @@
 
 ## Overview
 
-Build only the planning layer needed to keep a long Korean fiction project coherent across many chapters. Prefer reusable working documents over lore essays.
+Build only the planning layer needed to keep a long Korean fiction project coherent across many chapters. Prefer reusable working documents over lore essays, and prefer recovery packages over bare issue lists when the project already exists.
 
-Default to `greenfield build` when the user is starting from an idea, hook, synopsis, or loose cast concept. Treat repair and audit as secondary modes unless the request clearly starts from existing chapters.
+Use `series-qa` when the user wants report-only QA: ranked findings, severity, regression checking, or a diagnostic report that should not rebuild the project.
+Use `novel-writing` for scenes, chapters, prose, or stage-file drafting after the plan is stable.
+Use `character-voice-bible` for dialogue-only repair, register tuning, or cast-wide voice separation.
+Keep canon extraction, recovery planning, and re-entry packet design here when the goal is to restore the longform structure.
 
 ## Start With Intake
 
@@ -24,7 +27,7 @@ Lock the minimum facts before designing anything large:
 - known ending or ending promise
 - dominant risk: drift, escalation collapse, timeline collision, weak opposition, flat relationship motion, forgotten setup
 - likely package selection reason
-- requested output: bible, arc plan, chapter architecture, repair pass, drafting packet
+- requested output: bible, arc plan, chapter architecture, recovery pass, drafting packet
 
 If the prompt is vague, infer the smallest safe scope and state the assumption. For quick intake fields and risk triage, read [references/project-intake.md](references/project-intake.md).
 
@@ -39,10 +42,11 @@ Choose the main job first. Do not mix all modes unless the user clearly needs th
 
 - `greenfield build`
 - `rolling outline`
-- `drift repair`
-- `continuity audit`
+- `recovery audit`: extract canon, localize breakpoints, and produce a reusable recovery package
+- `recovery rebuild`: recover canon and structure from an existing, unstable draft, then produce a re-entry drafting packet
+- `continuity audit`: check timeline, knowledge, rules, and payoff consistency without rebuilding the whole project; use `series-qa` if the user only wants findings
 
-If the project is not yet drafted, stay in `greenfield build` long enough to lock the story engine, growth model, and first major architecture layer before producing chapter-by-chapter plans.
+If the user uses older drift-repair wording, normalize it to `recovery rebuild`. If the project is not yet drafted, stay in `greenfield build` long enough to lock the story engine, growth model, and first major architecture layer before producing chapter-by-chapter plans. If the project already exists, default to `recovery audit` or `recovery rebuild` before anything else.
 
 ## Prioritize The Story Engine
 
@@ -107,8 +111,9 @@ Default stacks:
 
 - `greenfield build`: story engine sheet, series brief, story bible, core cast matrix, first arc or volume plan
 - `rolling outline`: active arc plan, chapter-range plan, continuity ledger, payoff tracker
-- `drift repair`: canon extraction sheet, history spine, continuity ledger, knowledge-state tracker
-- `continuity audit`: continuity ledger, knowledge-state tracker, payoff tracker, drafting packet
+- `recovery audit`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet, continuity audit report
+- `recovery rebuild`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet
+- `continuity audit`: continuity ledger, knowledge-state tracker, payoff tracker; use `series-qa` if the user only wants findings
 
 Available deliverables:
 
@@ -127,6 +132,18 @@ Available deliverables:
 - promise/payoff tracker
 - canon extraction sheet
 - continuity audit report
+- recovery plan
+- re-entry drafting packet
+
+For `recovery audit` and `recovery rebuild`, always end with a reusable planning package:
+
+1. canon extraction sheet
+2. continuity ledger
+3. knowledge-state tracker
+4. recovery plan
+5. re-entry drafting packet
+
+The re-entry drafting packet must name one active repaired slice rather than the whole damaged run.
 
 ## Work In Layers
 
@@ -198,7 +215,7 @@ When the user wants actual scenes or chapters:
 1. finish or update the longform planning artifacts here
 2. if cast voice or dialogue differentiation is a visible risk, hand the dialogue layer to `character-voice-bible`
 3. hand narration, scene execution, and chapter prose to `novel-writing`
-4. after drafting, update continuity, knowledge state, and payoff status
+4. after drafting, record tracker update requirements; do not mutate orchestrator runtime state
 
 ## Default Answer Shape
 
@@ -219,6 +236,7 @@ Choose one depth level:
 - `concept pass`
 - `development pass`
 - `production pass`
+- `recovery pass`: add canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, and re-entry drafting packet
 
 Do not jump to production-pass density unless the user asked for detailed structure or the project is already stabilized.
 

--- a/skills/longform-story-design/SKILL.md
+++ b/skills/longform-story-design/SKILL.md
@@ -11,7 +11,7 @@ Build only the planning layer needed to keep a long Korean fiction project coher
 
 Use this skill for series-level architecture, canon recovery, continuity control, and reusable planning packages.
 
-- Use `series-qa` when the user wants diagnosis only: ranked findings, severity, regression checking, or a report that should not rebuild the project.
+- Use `series-qa` when the user wants report-only QA: ranked findings, severity, regression checking, or a diagnostic report that should not rebuild the project.
 - Use `novel-writing` when the user wants scenes, chapters, prose, or stage-file drafting after the plan is stable.
 - Use `character-voice-bible` when the main problem is dialogue-only repair, register tuning, or cast-wide voice separation.
 - Keep canon extraction, recovery planning, and re-entry packet design here when the goal is to restore the longform structure rather than only describe the break.
@@ -60,7 +60,7 @@ Lock the minimum facts before designing anything large, in canonical order:
 - alias resolution note, if the stated label is cross-package or ambiguous
 - project state: premise only, partial outline, existing chapters, or repair request
 - known ending or ending promise
-- requested output: bible, arc plan, chapter architecture, repair pass, drafting packet
+- requested output: bible, arc plan, chapter architecture, recovery pass, drafting packet
 
 If the prompt is vague, infer the smallest safe scope and state the assumption. For quick intake fields and risk triage, read [references/project-intake.md](references/project-intake.md).
 
@@ -79,7 +79,7 @@ Choose the main job first. Do not mix all modes unless the user clearly needs th
 - `recovery rebuild`: recover canon and structure from an existing, unstable draft, then produce a re-entry drafting packet
 - `continuity audit`: check timeline, knowledge, rules, and payoff consistency without rebuilding the whole project; use `series-qa` if the user only wants findings
 
-`drift repair` is the legacy label for `recovery rebuild`, and `continuity audit` remains the narrow audit-only lane when the user wants diagnosis more than reconstruction.
+If the user uses older drift-repair wording, normalize it to `recovery rebuild`. `continuity audit` remains the narrow audit-only lane when the user wants diagnosis more than reconstruction.
 
 If the project is not yet drafted, stay in `greenfield build` long enough to lock the story engine, growth model, and first major architecture layer before producing chapter-by-chapter plans. If the project already exists, default to `recovery audit` or `recovery rebuild` before anything else.
 
@@ -160,9 +160,9 @@ Default stacks:
 
 - `greenfield build`: story engine sheet, series brief, story bible, core cast matrix, first arc or volume plan
 - `rolling outline`: active arc plan, chapter-range plan, continuity ledger, payoff tracker
-- `recovery audit`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, continuity audit report
+- `recovery audit`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet, continuity audit report
 - `recovery rebuild`: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet
-- `continuity audit`: continuity ledger, knowledge-state tracker, payoff tracker, drafting packet
+- `continuity audit`: continuity ledger, knowledge-state tracker, payoff tracker; use `series-qa` if the user only wants findings
 
 When invoked for `series-completion-loop` `slice_planning`, override these general stacks with a current-batch slice packet only.
 
@@ -246,6 +246,16 @@ Omit only what does not govern the next safe move:
 - keep the re-entry drafting packet whenever prose drafting is expected next
 
 Do not return a bare issue list for a recovery job when this skill owns the response.
+
+## Recovery Boundary Drift Check
+
+After editing recovery routing, recovery artifact minimums, drafting handoff rules, or platform copies, run:
+
+```bash
+python3 skills/longform-story-design/scripts/validate_recovery_boundaries.py
+```
+
+Do not treat recovery-boundary edits as complete until the check passes.
 
 ## Work In Layers
 

--- a/skills/longform-story-design/references/handoff-to-drafting.md
+++ b/skills/longform-story-design/references/handoff-to-drafting.md
@@ -30,8 +30,10 @@ For multi-POV packets, include only the POVs that actually act inside the active
 ```text
 Project:
 Current arc:
+Recovery package source:
 Active repaired slice:
 Chapter or range:
+Re-entry reason:
 POV:
 Current emotional state:
 Current practical goal:
@@ -42,6 +44,7 @@ What this chapter must set up:
 What this chapter may pay off:
 Continuity constraints:
 Do not contradict:
+First safe draft objective:
 ```
 
 For orchestrated handoff, also include:

--- a/skills/longform-story-design/references/longform-workflow.md
+++ b/skills/longform-story-design/references/longform-workflow.md
@@ -95,17 +95,20 @@ If the user brings broken chapters, conflicting outlines, or a draft that no lon
 2. extract hard canon before suggesting changes
 3. separate timeline damage from motivation damage, knowledge damage, and payoff damage
 4. choose the smallest recovery bundle that clears the first blocking contradiction
-5. repair the active slice before expanding anything else
+5. define the active repaired slice before expanding anything else
 
 When this flow is invoked by `series-completion-loop`, keep recovery inside the current failed slice unless proof shows the first break point predates it. Do not expand into future batches while building the recovery package.
 
 Use this recovery bundle order:
 
 - canon extraction sheet
-- continuity audit report
+- continuity ledger
+- knowledge-state tracker
+- recovery plan
+- re-entry drafting packet
+- continuity audit report only as supporting evidence, not as the package itself
 - history spine if chronology is broken
 - revised active arc plan if the middle has lost direction
-- knowledge-state tracker if secrets or misunderstandings are failing
 - payoff tracker if setup debt is the main problem
 
 Only after the repaired slice is stable should you hand off a drafting packet.

--- a/skills/longform-story-design/references/planning-stack-selection.md
+++ b/skills/longform-story-design/references/planning-stack-selection.md
@@ -4,13 +4,13 @@ Use this file when deciding which longform design documents to create first.
 
 ## Deterministic Selection Rule
 
-Choose the stack in this order:
+Use this file only after the top-level order has already locked `mode -> package -> dominant risk`. Then choose the stack in this order:
 
-1. project state
+1. locked mode
 2. dominant risk
 3. scale
 
-Project state wins when it clearly says the work is greenfield, rolling, repair, or audit. If two stacks still fit, let dominant risk pick the first failure point. If state and risk still leave more than one valid stack, use scale to add only the trackers the project can actually sustain.
+Locked mode wins when it clearly says the work is greenfield, rolling, recovery, or report-only QA. If the user only wants ranked findings, route to `series-qa` instead of building a reconstruction stack. If two longform stacks still fit, let dominant risk pick the first failure point. If mode and risk still leave more than one valid stack, use scale to add only the trackers the project can actually sustain.
 
 When there is still a tie, choose the smaller stack that covers the first blocking problem. Do not add a document just because the project is large if a smaller recovery or drafting bundle already covers the next safe step.
 
@@ -18,13 +18,13 @@ When there is still a tie, choose the smaller stack that covers the first blocki
 
 When the caller is `series-completion-loop` in `slice_planning`, ignore scale-based expansion stacks beyond the active batch. Select only the smallest packet needed to plan `current_batch_start` through `current_batch_end`, normally the next `3~5화`, and carry forward no future-batch commitments.
 
-## By Project State
+## By Locked Mode Or Project State
 
 - premise only: story engine sheet, series brief, story bible
 - premise plus ending promise: story engine sheet, series brief, story bible, first volume or arc plan
 - partial outline: story engine sheet, story bible, arc plan, chapter-range plan
 - active drafting: chapter-range plan, continuity ledger, payoff tracker
-- existing messy draft: canon extraction sheet, continuity audit report, history spine, knowledge-state tracker, revised active arc plan if the middle has lost direction
+- existing messy draft: canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet, plus a history spine or revised active arc plan only if chronology or arc shape must be reset
 
 ## By Dominant Risk
 
@@ -36,6 +36,7 @@ When the caller is `series-completion-loop` in `slice_planning`, ignore scale-ba
 - secret handling failure: knowledge-state tracker, payoff tracker
 - setup with no return: payoff tracker, arc plan
 - serialization fatigue: chapter-range plan, drafting packet
+- report-only QA: route to `series-qa`; do not build recovery artifacts here
 
 If more than one risk applies, choose the one that would break the next handoff first. That risk decides the first stack, and the other risks only add documents if they change the next safe output.
 

--- a/skills/longform-story-design/references/project-intake.md
+++ b/skills/longform-story-design/references/project-intake.md
@@ -32,18 +32,18 @@ Match the dominant problem to the first artifact:
 - active chapter drafting drift -> continuity ledger and chapter-range plan
 - secrets or misunderstandings breaking -> knowledge-state tracker
 - setup not landing -> payoff tracker
-- existing contradictory draft -> canon extraction sheet and continuity audit report
-- damaged longform draft with multiple broken chapters -> repair bundle first, then chapter-safe drafting packet
+- existing contradictory draft -> recovery package with canon extraction sheet, continuity ledger, recovery plan, and re-entry drafting packet
+- damaged longform draft with multiple broken chapters -> recovery package first, then re-entry drafting packet
 
 If the request is already a repair request, do not route it through a fresh greenfield stack. Start with the smallest recovery bundle that removes the first blocking contradiction.
 
 First recovery bundle rules:
 
-- chronology or cause-and-effect damage -> canon extraction sheet, continuity audit report, history spine
-- middle drift or stalled momentum -> canon extraction sheet, continuity audit report, revised active arc plan
-- knowledge or secret-state damage -> canon extraction sheet, knowledge-state tracker, continuity audit report
-- payoff debt or dropped setup -> canon extraction sheet, payoff tracker, continuity audit report
-- long damaged draft with no clear safe chapter boundary -> canon extraction sheet, continuity audit report, then isolate the active repaired slice before any prose drafting
+- chronology or cause-and-effect damage -> canon extraction sheet, continuity ledger, recovery plan, re-entry drafting packet, plus history spine if chronology must be reset
+- middle drift or stalled momentum -> canon extraction sheet, continuity ledger, recovery plan, re-entry drafting packet, plus revised active arc plan if arc shape must be reset
+- knowledge or secret-state damage -> canon extraction sheet, continuity ledger, knowledge-state tracker, recovery plan, re-entry drafting packet
+- payoff debt or dropped setup -> canon extraction sheet, continuity ledger, payoff tracker, recovery plan, re-entry drafting packet
+- long damaged draft with no clear safe chapter boundary -> canon extraction sheet, continuity ledger, recovery plan, isolate the active repaired slice, then create a re-entry drafting packet before any prose drafting
 
 ## Genre Package Intake
 

--- a/skills/longform-story-design/references/repair-existing-draft.md
+++ b/skills/longform-story-design/references/repair-existing-draft.md
@@ -1,14 +1,14 @@
-# Repair Existing Draft
+# Recover Existing Draft
 
 Use this file when the user already has chapters, notes, or multiple outline versions that no longer agree.
 
-## Repair Order
+## Recovery Order
 
 1. index the existing material by chapter, arc, or document chunk
 2. extract hard canon before suggesting changes
 3. list contradictions without hiding them
 4. separate structural problems from prose problems
-5. decide the smallest repair set that lets drafting continue safely
+5. decide the smallest recovery package that lets drafting continue safely
 
 ## Hard Canon Extraction
 
@@ -22,7 +22,7 @@ Treat these as extract-first items:
 - promises made to the reader
 - dates, elapsed time, travel duration, training duration
 
-## Repair Triage
+## Recovery Triage
 
 Handle contradictions in this order:
 
@@ -34,18 +34,20 @@ Handle contradictions in this order:
 
 ## Output Pattern
 
-When repairing, prefer this bundle:
+When recovering an existing draft, prefer this reusable recovery package:
 
 - canon extraction sheet
-- continuity audit report
+- continuity ledger
+- recovery plan
+- re-entry drafting packet naming the active repaired slice
+- continuity audit report only as supporting evidence
 - revised history spine if chronology is broken
 - revised active arc plan if the middle has lost direction
-- drafting packet for the next safe chapter range
 
 For `series-completion-loop` `recovery_planning`, compress the bundle into one `recovery/latest-recovery.md` artifact with:
 
 - root cause
-- repair order
+- recovery order
 - next safe move
 - handoff target
 - must-not-break constraints

--- a/skills/longform-story-design/scripts/validate_recovery_boundaries.py
+++ b/skills/longform-story-design/scripts/validate_recovery_boundaries.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Validate longform-story-design recovery routing boundaries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+ROOT_FROM_SCRIPT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True)
+class RequiredText:
+    path: str
+    label: str
+    needles: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ForbiddenText:
+    path: str
+    label: str
+    needles: tuple[str, ...]
+
+
+REQUIRED_TEXTS: tuple[RequiredText, ...] = (
+    RequiredText(
+        "skills/longform-story-design/SKILL.md",
+        "root recovery ownership",
+        (
+            "report-only QA",
+            "`recovery audit`",
+            "`recovery rebuild`",
+            "reusable planning package",
+            "re-entry drafting packet",
+            "active repaired slice",
+            "python3 skills/longform-story-design/scripts/validate_recovery_boundaries.py",
+        ),
+    ),
+    RequiredText(
+        "skills/longform-story-design/references/project-intake.md",
+        "project intake recovery routing",
+        (
+            "recovery package first",
+            "re-entry drafting packet",
+            "active repaired slice",
+            "long damaged draft with no clear safe chapter boundary -> canon extraction sheet, continuity ledger, recovery plan, isolate the active repaired slice, then create a re-entry drafting packet before any prose drafting",
+        ),
+    ),
+    RequiredText(
+        "skills/longform-story-design/references/repair-existing-draft.md",
+        "existing draft recovery package",
+        (
+            "reusable recovery package",
+            "continuity ledger",
+            "recovery plan",
+            "re-entry drafting packet naming the active repaired slice",
+            "continuity audit report only as supporting evidence",
+            "recovery/latest-recovery.md",
+        ),
+    ),
+    RequiredText(
+        "skills/longform-story-design/references/planning-stack-selection.md",
+        "stack selection recovery routing",
+        (
+            "report-only QA",
+            "`series-qa`",
+            "recovery plan",
+            "re-entry drafting packet",
+        ),
+    ),
+    RequiredText(
+        "skills/longform-story-design/references/longform-workflow.md",
+        "workflow recovery flow",
+        (
+            "Recovery Flow For Damaged Longform Drafts",
+            "define the active repaired slice",
+            "recovery plan",
+            "re-entry drafting packet",
+        ),
+    ),
+    RequiredText(
+        "skills/longform-story-design/references/handoff-to-drafting.md",
+        "drafting handoff active slice",
+        (
+            "active repaired slice",
+            "Recovery package source:",
+            "Re-entry reason:",
+            "First safe draft objective:",
+        ),
+    ),
+    RequiredText(
+        "Platform/OpenAI/GPT-OSS/skills/longform-story-design/SKILL.md",
+        "GPT-OSS recovery ownership",
+        (
+            "report-only QA",
+            "`recovery audit`",
+            "`recovery rebuild`",
+            "reusable planning package",
+            "re-entry drafting packet",
+            "active repaired slice",
+        ),
+    ),
+    RequiredText(
+        "Platform/OpenAI/GPT-OSS/ROUTER.md",
+        "GPT-OSS router recovery routing",
+        (
+            "recovery audit",
+            "recovery rebuild",
+            "re-entry drafting packet",
+        ),
+    ),
+    RequiredText(
+        "Platform/OpenAI/GPT-OSS/SYSTEM_PROMPT.md",
+        "GPT-OSS system recovery routing",
+        (
+            "recovery audit/recovery rebuild",
+            "`longform-story-design`",
+        ),
+    ),
+)
+
+
+FORBIDDEN_TEXTS: tuple[ForbiddenText, ...] = (
+    ForbiddenText(
+        "Platform/OpenAI/GPT-OSS/skills/longform-story-design/SKILL.md",
+        "GPT-OSS stale recovery labels",
+        (
+            "`drift repair`",
+            "repair pass",
+        ),
+    ),
+    ForbiddenText(
+        "Platform/OpenAI/GPT-OSS/ROUTER.md",
+        "GPT-OSS router stale recovery labels",
+        (
+            "`drift repair`",
+            "repair pass",
+        ),
+    ),
+    ForbiddenText(
+        "skills/longform-story-design/references/repair-existing-draft.md",
+        "stale existing draft recovery bundle",
+        (
+            "drafting packet for the next safe chapter range",
+        ),
+    ),
+)
+
+
+def repo_root_from_args(argv: list[str]) -> Path:
+    if len(argv) > 2:
+        raise SystemExit("usage: validate_recovery_boundaries.py [repo-root]")
+    if len(argv) == 2:
+        return Path(argv[1]).resolve()
+    return ROOT_FROM_SCRIPT
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def check_required(root: Path, check: RequiredText) -> list[str]:
+    path = root / check.path
+    if not path.is_file():
+        return [f"{check.path}: missing file for {check.label}"]
+    text = read_text(path)
+    return [
+        f"{check.path}: missing {needle!r} for {check.label}"
+        for needle in check.needles
+        if needle not in text
+    ]
+
+
+def check_forbidden(root: Path, check: ForbiddenText) -> list[str]:
+    path = root / check.path
+    if not path.is_file():
+        return [f"{check.path}: missing file for {check.label}"]
+    text = read_text(path)
+    return [
+        f"{check.path}: forbidden {needle!r} for {check.label}"
+        for needle in check.needles
+        if needle in text
+    ]
+
+
+def main(argv: list[str]) -> int:
+    root = repo_root_from_args(argv)
+    failures: list[str] = []
+
+    for check in REQUIRED_TEXTS:
+        failures.extend(check_required(root, check))
+    for check in FORBIDDEN_TEXTS:
+        failures.extend(check_forbidden(root, check))
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}")
+        return 1
+
+    print("OK longform recovery boundary validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Split report-only QA from recovery audit/rebuild ownership in longform-story-design and GPT-OSS routing.
- Require recovery packages to include canon extraction, continuity ledger, recovery plan, re-entry drafting packet, and an active repaired slice.
- Add validate_recovery_boundaries.py plus regression coverage for stale recovery labels and missing handoff anchors.

## Verification
- python3 skills/longform-story-design/scripts/validate_recovery_boundaries.py
- python3 skills/series-qa/scripts/validate_diagnostic_boundaries.py
- python3 Platform/scripts/validate_skill_exposure.py
- python3 skills/series-completion-loop/scripts/validate_runtime_template.py
- git diff --cached --check
- negative temp-root checks for stale drift-repair labels and missing recovery handoff anchors

Closes #5
